### PR TITLE
Event Builder Class

### DIFF
--- a/src/furo-ui5-data-checkbox-input-labeled.js
+++ b/src/furo-ui5-data-checkbox-input-labeled.js
@@ -12,8 +12,6 @@ import './furo-ui5-data-checkbox-input.js';
  * The furo-ui5-data-checkbox-input-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {Boolean} field-value-changed - Fires the field value when it changes.
- *
  * @summary labeled input field
  * @customElement
  * @demo demo-furo-ui5-data-checkbox-input-labeled Basic Usage

--- a/src/furo-ui5-data-checkbox-input.js
+++ b/src/furo-ui5-data-checkbox-input.js
@@ -3,6 +3,7 @@ import { css } from 'lit';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The 'furo-ui5-data-checkbox-input' component allows the user to switch true and false for Bool with data binding.
@@ -37,13 +38,10 @@ import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
  *
  * ```
  *
- *
- *
- *
  * @fires {Boolean} change -  Fired when the checkbox checked state changes.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/CheckBox/).
  *
- * @fires {Boolean} field-value-changed - Fires the field value when it changes.
+ * @fires {Boolean} value-changed - Fires the field value when it changes.
  *
  * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
  * @summary data checkbox input field
@@ -163,12 +161,7 @@ export class FuroUi5DataCheckboxInput extends FieldNodeAdapter(
       this.setFnaFieldValue(this.checked);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.checked;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.checked));
   }
 
   /**

--- a/src/furo-ui5-data-date-picker-labeled.js
+++ b/src/furo-ui5-data-date-picker-labeled.js
@@ -12,7 +12,7 @@ import './furo-ui5-form-field-container.js';
  * The furo-ui5-data-date-picker-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes in ISO 8601 format.
+ * @fires {String} value-changed - Fires the field value when it changes in ISO 8601 format.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-date-picker.js
+++ b/src/furo-ui5-data-date-picker.js
@@ -2,6 +2,7 @@ import '@ui5/webcomponents/dist/generated/i18n/i18n-defaults.js';
 import * as DatePicker from '@ui5/webcomponents/dist/DatePicker.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The furo-ui5-data-date-picker component allows the user to bind an date object like google.type.Date or a date string
@@ -140,12 +141,7 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(
           }
       }
 
-      const customEvent = new Event('value-changed', {
-        composed: true,
-        bubbles: true,
-      });
-      customEvent.detail = this.dateValue;
-      this.dispatchEvent(customEvent);
+      this.dispatchEvent(Events.buildChangeEvent(this.dateValue));
     });
   }
 

--- a/src/furo-ui5-data-date-time-picker-labeled.js
+++ b/src/furo-ui5-data-date-time-picker-labeled.js
@@ -12,7 +12,7 @@ import './furo-ui5-form-field-container.js';
  * The furo-ui5-data-date-time-picker-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes in ISO 8601 format.
+ * @fires {String} value-changed - Fires the field value when it changes in ISO 8601 format.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-date-time-picker.js
+++ b/src/furo-ui5-data-date-time-picker.js
@@ -2,6 +2,7 @@ import '@ui5/webcomponents/dist/generated/i18n/i18n-defaults.js';
 import * as DateTimePicker from '@ui5/webcomponents/dist/DateTimePicker.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The furo-ui5-data-date-time-picker component allows the user to bind a date string
@@ -123,12 +124,7 @@ export class FuroUi5DataDateTimePicker extends FieldNodeAdapter(
        * Payload: {Date}
        * @type {Event}
        */
-      const customEvent = new Event('value-changed', {
-        composed: true,
-        bubbles: true,
-      });
-      customEvent.detail = this.dateValue;
-      this.dispatchEvent(customEvent);
+      this.dispatchEvent(Events.buildChangeEvent(this.dateValue));
     });
   }
 

--- a/src/furo-ui5-data-date-time-picker.js
+++ b/src/furo-ui5-data-date-time-picker.js
@@ -44,7 +44,7 @@ import { Events } from './lib/Events.js';
  *
  * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
  *
- * @fires {String} field-value-changed - Fires the field value when it changes in ISO 8601 format.
+ * @fires {String} value-changed - Fires the field value when it changes in ISO 8601 format.
  * @fires change - Fired when the input operation has finished by pressing Enter or on focusout.
  *
  * @summary furo data datetime picker field

--- a/src/furo-ui5-data-money-input-labeled.js
+++ b/src/furo-ui5-data-money-input-labeled.js
@@ -11,7 +11,7 @@ import './furo-ui5-data-money-input.js';
  * The furo-ui5-data-money-input-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {google.type.Money} field-value-changed - Fires the field value when it changes.
+ * @fires {google.type.Money} value-changed - Fires the field value when it changes.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-money-input.js
+++ b/src/furo-ui5-data-money-input.js
@@ -8,7 +8,7 @@ import '@ui5/webcomponents/dist/Input.js';
 import './furo-ui5-data-text-input.js';
 import { FieldNode } from '@furo/data/src/lib/FieldNode';
 import { RepeaterNode } from '@furo/data/src/lib/RepeaterNode';
-
+import { Events } from './lib/Events.js';
 /**
  * `furo-data-money-input`
  * Binds a entityObject field google.type.Money to a furo-number-input and currency dropdown fields
@@ -212,12 +212,7 @@ export class FuroUi5DataMoneyInput extends FBP(FieldNodeAdapter(LitElement)) {
         this.setFnaFieldValue(value);
       }
 
-      const customEvent = new Event('value-changed', {
-        composed: true,
-        bubbles: true,
-      });
-      customEvent.detail = value;
-      this.dispatchEvent(customEvent);
+      this.dispatchEvent(Events.buildChangeEvent(value));
     });
   }
 

--- a/src/furo-ui5-data-multi-input-labeled.js
+++ b/src/furo-ui5-data-multi-input-labeled.js
@@ -11,7 +11,7 @@ import './furo-ui5-data-multi-input.js';
  * The furo-ui5-data-multi-input-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires field-value-changed - Fires the field value when it changes.
+ * @fires value-changed - Fires the field value when it changes.
  *
  * @summary labeled textarea field
  * @customElement

--- a/src/furo-ui5-data-multi-input.js
+++ b/src/furo-ui5-data-multi-input.js
@@ -3,7 +3,7 @@ import * as MultiInput from '@ui5/webcomponents/dist/MultiInput.js';
 import '@ui5/webcomponents/dist/Token.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
-
+import { Events } from './lib/Events.js';
 /**
  * `furo-ui5-data-multi-input`
  *
@@ -265,12 +265,7 @@ export class FuroUi5DataMultiInput extends FieldNodeAdapter(
      * the event detail is the value of the repeated string
      * @type {Event}
      */
-    const customEvent = new Event('value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = val;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(val));
   }
 
   _removeAllItems() {

--- a/src/furo-ui5-data-number-input-labeled.js
+++ b/src/furo-ui5-data-number-input-labeled.js
@@ -11,7 +11,7 @@ import './furo-ui5-data-number-input.js';
  * The furo-ui5-data-number-input-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {Number} field-value-changed - Fires the field value when it changes.
+ * @fires {Number} value-changed - Fires the field value when it changes.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-number-input.js
+++ b/src/furo-ui5-data-number-input.js
@@ -47,7 +47,7 @@ import { Events } from './lib/Events.js';
  * @fires {} input -  Fired when the value of the ui5-input changes at each keystroke, and when a suggestion item has been selected.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
  *
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @summary data number input field
  * @customElement

--- a/src/furo-ui5-data-number-input.js
+++ b/src/furo-ui5-data-number-input.js
@@ -2,7 +2,7 @@ import * as Input from '@ui5/webcomponents/dist/Input.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@ui5/webcomponents/dist/features/InputSuggestions.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
-
+import { Events } from './lib/Events.js';
 /**
  * The 'furo-ui5-data-number-input' component allows the user to enter and edit numbers with data binding.
  *
@@ -190,12 +190,7 @@ export class FuroUi5DataNumberInput extends FieldNodeAdapter(Input.default) {
       this.setFnaFieldValue(value === '' ? 0 : value);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.value;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.value));
   }
 
   /**

--- a/src/furo-ui5-data-password-input-labeled.js
+++ b/src/furo-ui5-data-password-input-labeled.js
@@ -15,7 +15,7 @@ import './furo-ui5-data-password-input.js';
  *
  * @slot {HTMLElement} icon - defines the icon to be displayed in the input element.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-password-input.js
+++ b/src/furo-ui5-data-password-input.js
@@ -46,7 +46,7 @@ import { Events } from './lib/Events.js';
  * @fires {`text`} change -  Fired when the input operation has finished by pressing Enter or on focusout.
  * @fires {} input -  Fired when the value of the ui5-input changes at each keystroke, and when a suggestion item has been selected.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  * @fires {MouseEvent} icon-clicked - Fired when icon is clicked
  * @fires {void} password-showed - Fired when the password is showed, after calling the show method.
  * @fires {void} password-hidden - Fired when the password is hidden, after calling the hide() method.

--- a/src/furo-ui5-data-password-input.js
+++ b/src/furo-ui5-data-password-input.js
@@ -2,7 +2,7 @@ import * as Input from '@ui5/webcomponents/dist/Input.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@ui5/webcomponents/dist/features/InputSuggestions.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
-
+import { Events } from './lib/Events.js';
 /**
  * The 'furo-ui5-data-password-input' component allows the user to enter and edit password with data binding.
  *
@@ -195,12 +195,7 @@ export class FuroUi5PasswordInput extends FieldNodeAdapter(Input.default) {
       this.setFnaFieldValue(value === '' ? '' : value);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.value;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.value));
   }
 
   /**

--- a/src/furo-ui5-data-radio-button-group.js
+++ b/src/furo-ui5-data-radio-button-group.js
@@ -1,6 +1,7 @@
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
 import { RepeaterNode } from '@furo/data/src/lib/RepeaterNode.js';
 import '@ui5/webcomponents/dist/RadioButton.js';
+import { Events } from './lib/Events.js';
 
 /**
  * `furo-ui5-data-radio-button-group`
@@ -373,12 +374,7 @@ export class FuroUi5DataRadioButtonGroup extends FieldNodeAdapter(HTMLElement) {
      *  * @fires {String} field-value-changed - Fires the field value when it changes.
      * @type {Event}
      */
-    const customEvent = new Event('value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = selectedOption;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(selectedOption));
 
     const customSelectEvent = new Event('item-selected', {
       composed: true,

--- a/src/furo-ui5-data-radio-button-group.js
+++ b/src/furo-ui5-data-radio-button-group.js
@@ -371,7 +371,7 @@ export class FuroUi5DataRadioButtonGroup extends FieldNodeAdapter(HTMLElement) {
 
     /**
      * Fired when the value has changed
-     *  * @fires {String} field-value-changed - Fires the field value when it changes.
+     *  * @fires {String} value-changed - Fires the field value when it changes.
      * @type {Event}
      */
     this.dispatchEvent(Events.buildChangeEvent(selectedOption));

--- a/src/furo-ui5-data-radio-button.js
+++ b/src/furo-ui5-data-radio-button.js
@@ -1,6 +1,7 @@
 import * as RadioButton from '@ui5/webcomponents/dist/RadioButton.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The 'furo-ui5-data-radio-button' component allows the user to switch true and false for Bool with data binding.
@@ -53,7 +54,7 @@ import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
  *
  * @fires {} select -  Fired when the input operation has finished by pressing Enter or on focusout.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/ToggleButton/).
- * @fires {Boolean} field-value-changed - Fired when value changed
+ * @fires {Boolean} value-changed - Fired when value changed
  *
  * @summary boolean toggle button
  * @customElement
@@ -141,12 +142,7 @@ export class FuroUi5DataRadioButton extends FieldNodeAdapter(
       this.setFnaFieldValue(this.checked);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.checked;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.checked));
   }
 
   /**

--- a/src/furo-ui5-data-segmented-button.js
+++ b/src/furo-ui5-data-segmented-button.js
@@ -377,7 +377,7 @@ export class FuroUi5DataSegmentedButton extends FieldNodeAdapter(
      * Payload:
      *  - if no option binding is active: ui5-segmented-button-item
      *  - if a RepeaterNode is bound: FieldNode
-     *  * @fires {String} field-value-changed - Fires the field value when it changes.
+     *  * @fires {String} value-changed - Fires the field value when it changes.
      * @type {Event}
      */
     this.dispatchEvent(Events.buildChangeEvent(selectedOption));

--- a/src/furo-ui5-data-segmented-button.js
+++ b/src/furo-ui5-data-segmented-button.js
@@ -2,6 +2,7 @@ import * as SegmentedButton from '@ui5/webcomponents/dist/SegmentedButton.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
 import { RepeaterNode } from '@furo/data/src/lib/RepeaterNode.js';
 import '@ui5/webcomponents/dist/SegmentedButtonItem.js';
+import { Events } from './lib/Events.js';
 
 /**
  * `furo-ui5-data-segmented-button`
@@ -379,12 +380,7 @@ export class FuroUi5DataSegmentedButton extends FieldNodeAdapter(
      *  * @fires {String} field-value-changed - Fires the field value when it changes.
      * @type {Event}
      */
-    const customEvent = new Event('value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = selectedOption;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(selectedOption));
 
     const customSelectEvent = new Event('item-selected', {
       composed: true,

--- a/src/furo-ui5-data-select-labeled.js
+++ b/src/furo-ui5-data-select-labeled.js
@@ -13,7 +13,7 @@ import './furo-ui5-data-select.js';
  *
  * @slot {HTMLElement} valueStateMessage - defines the value state message that will be displayed as pop up under the input element.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @summary labeled select
  * @customElement

--- a/src/furo-ui5-data-select.js
+++ b/src/furo-ui5-data-select.js
@@ -1,6 +1,7 @@
 import * as Select from '@ui5/webcomponents/dist/Select.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
 import { RepeaterNode } from '@furo/data/src/lib/RepeaterNode.js';
+import { Events } from './lib/Events.js';
 
 import '@ui5/webcomponents/dist/Option.js';
 
@@ -582,12 +583,7 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
       }
     }
 
-    const customEvent = new Event('value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = selectedOption;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(selectedOption));
 
     const customSelectEvent = new Event('item-selected', {
       composed: true,

--- a/src/furo-ui5-data-select.js
+++ b/src/furo-ui5-data-select.js
@@ -18,7 +18,7 @@ import '@ui5/webcomponents/dist/Option.js';
  *
  * @fires {optionNodeList} options-updated - Fired  after the option list was rebuilt.
  * @fires {selectedOption} item-selected - Fired when the item of the dropdown list is selected.
- * @fires {selectedOption} field-value-changed - Fires the field value when it changes.
+ * @fires {selectedOption} value-changed - Fires the field value when it changes.
  *
  * @summary data select field
  * @customElement

--- a/src/furo-ui5-data-text-input-labeled.js
+++ b/src/furo-ui5-data-text-input-labeled.js
@@ -13,7 +13,7 @@ import './furo-ui5-data-text-input.js';
  *
  * @slot {HTMLElement} icon - defines the icon to be displayed in the input element.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @slot {HTMLElement} icon - Defines the icon to be displayed in the input.
  * @summary labeled input field

--- a/src/furo-ui5-data-text-input.js
+++ b/src/furo-ui5-data-text-input.js
@@ -48,7 +48,7 @@ import { Events } from './lib/Events.js';
  * @fires {} input -  Fired when the value of the ui5-input changes at each keystroke, and when a suggestion item has been selected.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
  *
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @summary data text input field
  * @customElement

--- a/src/furo-ui5-data-text-input.js
+++ b/src/furo-ui5-data-text-input.js
@@ -2,6 +2,7 @@ import * as Input from '@ui5/webcomponents/dist/Input.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@ui5/webcomponents/dist/features/InputSuggestions.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The 'furo-ui5-data-text-input' component allows the user to enter and edit texts with data binding.
@@ -195,12 +196,7 @@ export class FuroUi5DataTextInput extends FieldNodeAdapter(Input.default) {
       this.setFnaFieldValue(value === '' ? '' : value);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.value;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.value));
   }
 
   /**

--- a/src/furo-ui5-data-textarea-input-labeled.js
+++ b/src/furo-ui5-data-textarea-input-labeled.js
@@ -20,7 +20,7 @@ export class FuroUi5DataTextareaInputLabeled extends FBP(LitElement) {
   /**
    * Fired when the input value changed.
    * the event detail is the value of the input field
-   *  * @fires {String} field-value-changed - Fires the field value when it changes.
+   *  * @fires {String} value-changed - Fires the field value when it changes.
    */
 
   constructor() {

--- a/src/furo-ui5-data-textarea-input.js
+++ b/src/furo-ui5-data-textarea-input.js
@@ -1,5 +1,6 @@
 import * as TextArea from '@ui5/webcomponents/dist/TextArea.js';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The 'furo-ui5-data-textarea-input' component allows the user to enter and edit texts with data binding.
@@ -199,12 +200,7 @@ export class FuroUi5DataTextareaInput extends FieldNodeAdapter(
       this.setFnaFieldValue(value === '' ? '' : value);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.value;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.value));
   }
 
   /**

--- a/src/furo-ui5-data-textarea-input.js
+++ b/src/furo-ui5-data-textarea-input.js
@@ -48,7 +48,7 @@ import { Events } from './lib/Events.js';
  * @fires {`text`} change -  Fired when the input operation has finished by pressing Enter or on focusout.
  * @fires {} input -  Fired when the value of the ui5-input changes at each keystroke.
  * @fires {} xxxx -  All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
- * @fires {String} field-value-changed - Fires the field value when it changes.
+ * @fires {String} value-changed - Fires the field value when it changes.
  *
  * @summary data textarea input field
  * @customElement

--- a/src/furo-ui5-data-time-picker-labeled.js
+++ b/src/furo-ui5-data-time-picker-labeled.js
@@ -12,7 +12,7 @@ import './furo-ui5-form-field-container.js';
  * The furo-ui5-data-time-picker-labeled is a composition to easily use a complete input field with label according
  * to the design specification of SAP Fiori Design System.
  *
- * @fires {String} field-value-changed - Fires the field value when it changes in ISO 8601 format.
+ * @fires {String} value-changed - Fires the field value when it changes in ISO 8601 format.
  *
  * @summary labeled input field
  * @customElement

--- a/src/furo-ui5-data-time-picker.js
+++ b/src/furo-ui5-data-time-picker.js
@@ -43,7 +43,7 @@ import { Events } from './lib/Events.js';
  *
  * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
  *
- * @fires {String} field-value-changed - Fires the field value when it changes in ISO 8601 format.
+ * @fires {String} value-changed - Fires the field value when it changes in ISO 8601 format.
  * @fires change - Fired when the input operation has finished by pressing Enter or on focusout.
  *
  * @summary furo data time picker field

--- a/src/furo-ui5-data-time-picker.js
+++ b/src/furo-ui5-data-time-picker.js
@@ -2,6 +2,7 @@ import '@ui5/webcomponents/dist/generated/i18n/i18n-defaults.js';
 import * as TimePicker from '@ui5/webcomponents/dist/TimePicker.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
 
 /**
  * The furo-ui5-data-time-picker component allows the user to bind a field of type google.type.TimeOfDay.
@@ -140,12 +141,7 @@ export class FuroUi5DataTimePicker extends FieldNodeAdapter(
      * Payload: {Time}
      * @type {Event}
      */
-    const customEvent = new Event('value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.dateValue;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.dateValue));
   }
 
   /**

--- a/src/furo-ui5-data-toggle-button.js
+++ b/src/furo-ui5-data-toggle-button.js
@@ -1,7 +1,7 @@
 import * as ToggleButton from '@ui5/webcomponents/dist/ToggleButton.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
-
+import { Events } from './lib/Events.js';
 /**
  * The 'furo-ui5-data-toggle-button' component allows the user to switch true and false for Bool with data binding.
  *
@@ -44,7 +44,7 @@ import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
  *
  * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
  *
- * @fires {Boolean} field-value-changed - Fires the value of pressed when value changed.
+ * @fires {Boolean} value-changed - Fires the value of pressed when value changed.
  *
  * @summary boolean toggle button
  * @customElement
@@ -132,12 +132,7 @@ export class FuroUi5DataToggleButton extends FieldNodeAdapter(
       this.setFnaFieldValue(this.pressed);
     }
 
-    const customEvent = new Event('field-value-changed', {
-      composed: true,
-      bubbles: true,
-    });
-    customEvent.detail = this.pressed;
-    this.dispatchEvent(customEvent);
+    this.dispatchEvent(Events.buildChangeEvent(this.pressed));
   }
 
   /**

--- a/src/furo-ui5-notification-list-display.js
+++ b/src/furo-ui5-notification-list-display.js
@@ -15,7 +15,7 @@ import '@ui5/webcomponents/dist/List.js';
  *  you can also use more than one furo-ui5-notification-list for special needs.
  *  But you have to be sure the furo-ui5-notification-list can receive the notification events from furo-ui5-notification.
  *
- * @fires {Number} field-value-changed - Fires a notification counter changed. Use this event to show the amount of notifications to the user.
+ * @fires {Number} value-changed - Fires a notification counter changed. Use this event to show the amount of notifications to the user.
  *
  * @summary ui5 notification list
  * @customElement

--- a/src/lib/Events.js
+++ b/src/lib/Events.js
@@ -1,0 +1,23 @@
+/**
+ * Event Builder Class
+ */
+
+const VALUE_CHANGED = 'value-changed';
+
+export class Events {
+  /**
+   * Creates an universal `value-changed` event
+   * All extended ui5 components should use this builder function to create
+   * the change event
+   * @param detail
+   * @returns {Event}
+   */
+  static buildChangeEvent(detail) {
+    const customEvent = new Event(VALUE_CHANGED, {
+      composed: true,
+      bubbles: true,
+    });
+    customEvent.detail = detail;
+    return customEvent;
+  }
+}

--- a/tmp/components/custom-elements.json
+++ b/tmp/components/custom-elements.json
@@ -1124,15 +1124,6 @@
               "attribute": "readonly"
             }
           ],
-          "events": [
-            {
-              "type": {
-                "text": "Boolean"
-              },
-              "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
-            }
-          ],
           "attributes": [
             {
               "name": "label",
@@ -1953,7 +1944,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes in ISO 8601 format.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -2276,7 +2267,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes in ISO 8601 format.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -2479,7 +2470,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes in ISO 8601 format.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             },
             {
               "description": "Fired when the input operation has finished by pressing Enter or on focusout.",
@@ -2711,7 +2702,7 @@
                 "text": "google.type.Money"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -3116,7 +3107,7 @@
           "events": [
             {
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -3498,7 +3489,7 @@
                 "text": "Number"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -3840,7 +3831,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -3966,7 +3957,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -4327,7 +4318,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             },
             {
               "type": {
@@ -4978,7 +4969,7 @@
                 "text": "Boolean"
               },
               "description": "Fired when value changed",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -6331,7 +6322,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -6723,7 +6714,7 @@
                 "text": "selectedOption"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -7104,7 +7095,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -7459,7 +7450,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -7903,7 +7894,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -8007,7 +7998,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes in ISO 8601 format.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -8225,7 +8216,7 @@
                 "text": "String"
               },
               "description": "Fires the field value when it changes in ISO 8601 format.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             },
             {
               "description": "Fired when the input operation has finished by pressing Enter or on focusout.",
@@ -8437,7 +8428,7 @@
                 "text": "Boolean"
               },
               "description": "Fires the value of pressed when value changed.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "mixins": [
@@ -9505,7 +9496,7 @@
                 "text": "Number"
               },
               "description": "Fires a notification counter changed. Use this event to show the amount of notifications to the user.",
-              "name": "field-value-changed"
+              "name": "value-changed"
             }
           ],
           "attributes": [
@@ -10255,6 +10246,45 @@
           "declaration": {
             "name": "CollectionDropdownHelper",
             "module": "src/lib/DELETEMECollectionDropdownHelper.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/lib/Events.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "Events",
+          "members": [
+            {
+              "kind": "method",
+              "name": "buildChangeEvent",
+              "static": true,
+              "parameters": [
+                {
+                  "name": "detail"
+                }
+              ],
+              "description": "Creates an universal `value-changed` event\nAll extended ui5 components should use this builder function to create\nthe change event",
+              "return": {
+                "type": {
+                  "text": "Event"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Events",
+          "declaration": {
+            "name": "Events",
+            "module": "src/lib/Events.js"
           }
         }
       ]


### PR DESCRIPTION
Use of a universal event builder class to avoid inconsistent event names.

`
import { Events } from './lib/Events.js';
...
this.dispatchEvent(Events.buildChangeEvent(DETAIL));
`