### PR TITLE
Lazy loaded options for text input

### DIFF
--- a/demos/furo-ui5-text-input.html
+++ b/demos/furo-ui5-text-input.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {
+      background: #fafafa;
+    }
+    furo-demo-snippet{
+      height: 90vh;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+<div id="demo"></div>
+
+<script type="module">
+  import { html, render } from 'lit';
+  import './initEnv.js';
+  import '../src/furo-ui5-text-input.js';
+
+  import '@furo/route/src/furo-location.js';
+  import '@furo/data/src/furo-deep-link.js';
+  import '@furo/data/src/furo-collection-agent.js';
+  import '@furo/data/src/furo-data-object.js';
+  import '@furo/util/src/doc/furo-demo-snippet.js';
+  import '@furo/layout/src/furo-form-layouter.js';
+
+  import '@ui5/webcomponents/dist/Icon.js';
+  import '@ui5/webcomponents-icons/dist/search.js';
+
+
+  render(
+    html`
+
+        <furo-demo-snippet>
+          <template>
+
+            <furo-form-layouter two>
+              <p full>
+                FuroUi5TextInput with static suggestions.
+              </p>
+              <furo-ui5-text-input
+                label="use with text-input"
+                ƒ-bind-data="--daoPerson(*.sex)">
+              </furo-ui5-text-input>
+              <p full>
+                FuroUi5TextInput with search integration to show lazy loaded suggestions.
+              </p>
+              <furo-ui5-text-input
+                label="use with text-input"
+                display-field-path="data.first_name"
+                ƒ-bind-data="--daoPerson(*.sex)"
+                ƒ-bind-options="--collection(*.entities)">
+                <ui5-icon slot="icon" name="search" interactive @-click="--iconClicked"></ui5-icon>
+              </furo-ui5-text-input>
+            </furo-form-layouter>
+            <furo-data-object type="person.Person" @-object-ready="--daoPerson"></furo-data-object>
+
+            <furo-data-object type="person.PersonCollection" @-object-ready="--collection" ƒ-inject-raw="--response"></furo-data-object>
+
+            <furo-location @-location-changed="--locationChanged"></furo-location>
+            <furo-deep-link service="PersonService" @-hts-out="--hts" ƒ-qp-in="--locationChanged(*.query)"></furo-deep-link>
+
+            <furo-collection-agent service="PersonService" ƒ-hts-in="--hts" ƒ-list="--iconClicked" @-response="--response">
+            </furo-collection-agent>
+
+
+          </template>
+        </furo-demo-snippet>
+
+
+      `,
+    document.querySelector('#demo')
+  );
+</script>
+</body>
+</html>

--- a/demos/furo-ui5-text-input.html
+++ b/demos/furo-ui5-text-input.html
@@ -50,7 +50,8 @@
               </p>
               <furo-ui5-text-input
                 label="use with text-input"
-                display-field-path="data.first_name"
+                display-field-path="data.name"
+                desc-field-path="data.display_name"
                 ƒ-bind-data="--daoPerson(*.sex)"
                 ƒ-bind-options="--collection(*.entities)">
                 <ui5-icon slot="icon" name="search" interactive @-click="--iconClicked"></ui5-icon>

--- a/demos/index.html
+++ b/demos/index.html
@@ -27,6 +27,7 @@
   <li><a href="/demos/reference-search.html">reference-search</a></li>
   <li><a href="/demos/segmented-button.html">segmented-button</a></li>
   <li><a href="/demos/delay.html">delay</a></li>
+  <li><a href="/demos/furo-ui5-text-input.html">furo-ui5-text-input</a></li>
 </ul>
 
 

--- a/hugo/content/docs/components/_components-inside.md
+++ b/hugo/content/docs/components/_components-inside.md
@@ -1,0 +1,66 @@
+---
+booksearchexclude: false
+bookToc: false
+bookHidden: true
+---
+
+### Components
+
+- [furo-ui5-bool-icon](furo-ui5-bool-icon.md) Displays a icon for a boolean value
+- [furo-ui5-busy-indicator](furo-ui5-busy-indicator.md) ui5 busy indicator with methods
+- [furo-ui5-button](furo-ui5-button.md) ui5 button with methods
+- [furo-ui5-card](furo-ui5-card.md) Ui5 card with data bindings
+- [furo-ui5-chart-display](furo-ui5-chart-display.md) Display charts with data objects
+- [furo-ui5-chart](furo-ui5-chart.md) connect data to a chart
+- [furo-ui5-checkbox-input-labeled](furo-ui5-checkbox-input-labeled.md) labeled input field
+- [furo-ui5-checkbox-input](furo-ui5-checkbox-input.md) data checkbox input field
+- [furo-ui5-context-menu-display](furo-ui5-context-menu-display.md) context menu
+- [furo-ui5-context-menu](furo-ui5-context-menu.md) Context menu
+- [furo-ui5-date-picker-labeled](furo-ui5-date-picker-labeled.md) labeled input field
+- [furo-ui5-date-picker](furo-ui5-date-picker.md) bindable datepicker field
+- [furo-ui5-date-time-picker-labeled](furo-ui5-date-time-picker-labeled.md) labeled input field
+- [furo-ui5-date-time-picker](furo-ui5-date-time-picker.md) furo data datetime picker field
+- [furo-ui5-dialog-display](furo-ui5-dialog-display.md) Display element for furo-ui5-dialog
+- [furo-ui5-dialog](furo-ui5-dialog.md) Dialog element
+- [furo-ui5-flexible-grid](furo-ui5-flexible-grid.md) a grid splitter
+- [furo-ui5-form-field-container](furo-ui5-form-field-container.md) responsive labels for your input elements
+- [furo-ui5-header-panel](furo-ui5-header-panel.md) A bindable header panel
+- [furo-ui5-message-strip-display](furo-ui5-message-strip-display.md) furo ui5 message strip
+- [furo-ui5-message-strip](furo-ui5-message-strip.md) furo ui5 message strip
+- [furo-ui5-money-input-labeled](furo-ui5-money-input-labeled.md) labeled input field
+- [furo-ui5-money-input](furo-ui5-money-input.md) Binds a entityObject field google.type.Money to a number-input and currency dropdown fields
+- [furo-ui5-multi-input-labeled](furo-ui5-multi-input-labeled.md) labeled textarea field
+- [furo-ui5-multi-input](furo-ui5-multi-input.md) repeated strings
+- [furo-ui5-notification-group-display](furo-ui5-notification-group-display.md) ui5 notification group display
+- [furo-ui5-notification-list-display](furo-ui5-notification-list-display.md) ui5 notification list
+- [furo-ui5-notification](furo-ui5-notification.md) trigger component for notifications
+- [furo-ui5-number-input-labeled](furo-ui5-number-input-labeled.md) labeled input field
+- [furo-ui5-number-input](furo-ui5-number-input.md) data number input field
+- [furo-ui5-pagination-bar](furo-ui5-pagination-bar.md) Pagination Bar
+- [furo-ui5-password-input-labeled](furo-ui5-password-input-labeled.md) labeled input field
+- [furo-ui5-password-input](furo-ui5-password-input.md) data password input field
+- [furo-ui5-property](furo-ui5-property.md) ????? bind types of type any
+- [furo-ui5-typerenderer-labeled](furo-ui5-typerenderer-labeled.md) 
+- [furo-ui5-radio-button](furo-ui5-radio-button.md) boolean toggle button
+- [furo-ui5-reference-search](furo-ui5-reference-search.md) labeled input field
+- [furo-ui5-reference-search](furo-ui5-reference-search.md) furo ui5 data reference search
+- [furo-ui5-segmented-button](furo-ui5-segmented-button.md) segmented button
+- [furo-ui5-select-labeled](furo-ui5-select-labeled.md) labeled select
+- [furo-ui5-select](furo-ui5-select.md) data select field
+- [furo-ui5-sign-pad](furo-ui5-sign-pad.md) draw or sign
+- [furo-ui5-table](furo-ui5-table.md) Display repeated fields in a table
+- [furo-ui5-text-input-labeled](furo-ui5-text-input-labeled.md) labeled input field
+- [furo-ui5-text-input](furo-ui5-text-input.md) data text input field
+- [furo-ui5-textarea-input-labeled](furo-ui5-textarea-input-labeled.md) labeled textarea field
+- [furo-ui5-textarea-input](furo-ui5-textarea-input.md) data textarea input field
+- [furo-ui5-time-picker-labeled](furo-ui5-time-picker-labeled.md) labeled input field
+- [furo-ui5-time-picker](furo-ui5-time-picker.md) furo data time picker field
+- [furo-ui5-toggle-button](furo-ui5-toggle-button.md) boolean toggle button
+- [furo-ui5-tree](furo-ui5-tree.md) tree navigation menu
+- [furo-ui5-typerenderer-labeled](furo-ui5-typerenderer-labeled.md) labeled input field
+- [furo-ui5-z-grid](furo-ui5-z-grid.md) grid with a z pattern
+- [ui5-reference-search-item](ui5-reference-search-item.md) representation of a result item
+- [furo-ui5-context-menu-item](furo-ui5-context-menu-item.md) context menu item
+- [furo-ui5-context-submenu](furo-ui5-context-submenu.md) helper
+- [furo-ui5-table-row](furo-ui5-table-row.md) 
+- [furo-ui5-tree-item](furo-ui5-tree-item.md) tree item

--- a/hugo/content/docs/components/furo-ui5-text-input.md
+++ b/hugo/content/docs/components/furo-ui5-text-input.md
@@ -49,7 +49,7 @@ You can bind any `string` type, like `furo.fat.String` type or the `google.proto
 The constraint **required** will mark the element as required
 
 ## Methods
-**bind-data(fieldNode)**
+**bindData(fieldNode)**
 Bind a entity field. You can use the entity even when no data was received.
 
 When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
@@ -87,10 +87,36 @@ When you use @-object-ready from a furo-data-object which emits a EntityNode, ju
 
 
 
+
+
+
 ### **type**
 default: **&#39;Text&#39;**</small>
 
 
+<br><br>
+
+
+### **displayFieldPath**
+default: **&#39;display_name&#39;**</small>
+
+Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the text of the
+option items.
+Point-separated path to the field
+E.g. data.partner.display_name
+default: display_name
+This attribute is related to the option list
+<br><br>
+
+### **descFieldPath**
+default: **&#39;id&#39;**</small>
+
+Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the additional
+description of the option items.
+Point-separated path to the field
+E.g. data.partner.id
+default: id
+This attribute is related to the option list
 <br><br>
 
 
@@ -152,6 +178,23 @@ Use this after manual or scripted update of the attributes.
 
 
 
+
+
+
+
+
+
+### **bindOptions**
+<small>**bindOptions**(*repeaterNode* `` ) ⟹ `void`</small>
+
+<small>`` </small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-bind-options</span>
+
+Here a RepeaterNode can be connected to the component as an option list.
+The items are displayed as suggestion items.
+
+- <small>repeaterNode </small>
+<br><br>
 
 
 

--- a/src/furo-ui5-text-input.js
+++ b/src/furo-ui5-text-input.js
@@ -67,7 +67,8 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
     this._optionList = {};
 
     /**
-     * Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the option items.
+     * Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the text of the
+     * option items.
      * Point-separated path to the field
      * E.g. data.partner.display_name
      * default: display_name
@@ -75,6 +76,17 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
      * @type {string}
      */
     this.displayFieldPath = 'display_name';
+
+    /**
+     * Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the additional
+     * description of the option items.
+     * Point-separated path to the field
+     * E.g. data.partner.id
+     * default: id
+     * This attribute is related to the option list
+     * @type {string}
+     */
+    this.descFieldPath = 'id';
 
     /**
      * used to restore the state after an invalidation -> validation change
@@ -125,7 +137,6 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
      * they can not be modified later via response or spec
      * null is used because getAttribute returns null or value
      *
-     *
      * @private
      */
     this._privilegedAttributes = {
@@ -136,6 +147,7 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
       icon: null,
       maxlength: null,
       'display-field-path': 'display_name',
+      'desc-field-path': 'id',
     };
 
     this.addEventListener('input', this._updateFNA);
@@ -194,7 +206,9 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
 
     // save the original attribute for later usages, we do this, because some components reflect
     Object.keys(this._privilegedAttributes).forEach(attr => {
-      this._privilegedAttributes[attr] = this.getAttribute(attr);
+      if (this.getAttribute(attr) !== null) {
+        this._privilegedAttributes[attr] = this.getAttribute(attr);
+      }
     });
     if (this._privilegedAttributes.icon) {
       this._setIcon(this._privilegedAttributes.icon);
@@ -632,7 +646,6 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
    * Supported fields are:
    * - text
    * - description
-   * - icon
    *
    * @param repeaterNode
    * @returns {*[]}
@@ -645,6 +658,7 @@ export class FuroUi5TextInput extends FieldNodeAdapter(Input.default) {
     repeaterNode.repeats.forEach((item) =>{
       const option = {};
       option.text = FuroUi5TextInput.getValueByPath(item, this._privilegedAttributes['display-field-path'])._value
+      option.display_name = FuroUi5TextInput.getValueByPath(item, this._privilegedAttributes['desc-field-path'])._value
       mappedOptions.push(option);
     })
     return mappedOptions;


### PR DESCRIPTION
**This PR allows an option list to be bound to the text field with the bindOptions(repeaterNode) function.**

The mapping is set with two attributes.

/**
     * Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the text of the
     * option items.
     * Point-separated path to the field
     * E.g. data.partner.display_name
     * default: display_name
     * This attribute is related to the option list
     * @type {string}
     */
    this.displayFieldPath = 'display_name';

 /**
     * Defines the field path that is used from the bound RepeaterNode (bindOptions) to display the additional
     * description of the option items.
     * Point-separated path to the field
     * E.g. data.partner.id
     * default: id
     * This attribute is related to the option list
     * @type {string}
     */
    this.descFieldPath = 'id';

**Usage**

`<furo-ui5-text ƒ-bind-data="--dao(*.field)" ƒ-bind-options="--daoCollection(*.entities)" display-field-path="data.field"></furo-ui5-text>`