### PR TITLE
Feature/comp rating indicator

### DIFF
--- a/demos/furo-ui5-rating-indicator.html
+++ b/demos/furo-ui5-rating-indicator.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {
+      background: #fafafa;
+      --furo-form-layouter-row-gap: var(--spacing-s, 16px);
+      --furo-form-layouter-column-gap: var(--spacing-s, 16px);
+    }
+    furo-demo-snippet{
+      height: 90vh;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+<div id="demo"></div>
+
+<script type="module">
+  import { html, render } from 'lit';
+  import './initEnv.js';
+  import '../src/furo-ui5-rating-indicator.js';
+  import '../src/furo-ui5-number-input.js';
+
+  import '@furo/data/src/furo-data-object.js';
+  import '@furo/util/src/doc/furo-demo-snippet.js';
+  import '@furo/layout/src/furo-form-layouter.js';
+
+  import '@ui5/webcomponents/dist/Icon.js';
+  import '@ui5/webcomponents-icons/dist/search.js';
+
+
+  render(
+    html`
+
+        <furo-demo-snippet>
+          <template>
+
+            <furo-form-layouter two>
+              <p full>
+                FuroUi5RatingIndicator int32
+              </p>
+              <furo-ui5-rating-indicator max="33" ƒ-bind-data="--daoPerson(*.bmi)"></furo-ui5-rating-indicator>
+              <furo-ui5-number-input ƒ-bind-data="--daoPerson(*.bmi)"></furo-ui5-number-input>
+
+              <p full>
+                FuroUi5RatingIndicator google.protobuf.Int32Value
+              </p>
+              <furo-ui5-rating-indicator max="7" ƒ-bind-data="--daoExp(*.wrapper_int32)"></furo-ui5-rating-indicator>
+              <furo-ui5-number-input ƒ-bind-data="--daoExp(*.wrapper_int32)"></furo-ui5-number-input>
+
+              <p full>
+                FuroUi5RatingIndicator furo.fat.Float
+              </p>
+              <furo-ui5-rating-indicator max="5" ƒ-bind-data="--daoExp(*.fat_float)"></furo-ui5-rating-indicator>
+              <furo-ui5-number-input ƒ-bind-data="--daoExp(*.fat_float)"></furo-ui5-number-input>
+            </furo-form-layouter>
+
+            <furo-data-object type="person.Person" @-object-ready="--daoPerson"></furo-data-object>
+            <furo-data-object type="universaltest.Universaltest" @-object-ready="--daoExp"></furo-data-object>
+
+          </template>
+        </furo-demo-snippet>
+
+
+      `,
+    document.querySelector('#demo')
+  );
+</script>
+</body>
+</html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -38,6 +38,7 @@
   <li><a href="/demos/select.html">furo-ui5-select</a></li>
   <li><a href="/demos/furo-ui5-password-input.html">furo-ui5-password-input</a></li>
   <li><a href="/demos/furo-ui5-multi-input.html">furo-ui5-multi-input</a></li>
+  <li><a href="/demos/furo-ui5-rating-indicator.html">furo-ui5-rating-indicator</a></li>
 </ul>
 
 

--- a/hugo/content/docs/components/.md
+++ b/hugo/content/docs/components/.md
@@ -1,223 +1,60 @@
 ---
 title: 
-description: data textarea input field
+description: ui5 busy indicator with methods
 weight: 50
 ---
 
 # 
-**@furo/components** <small>v1.0.0-rc.7</small>
-<br>`import '@furo/components/src/.js';`<small>
-<br>exports *FuroUi5TextareaInput* js
-<br>extends *src/furo-ui5-textarea-input.js*
-<br> mixes *FieldNodeAdapter*</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
+<br>`import '@furo/ui5/src/furo-ui5-busy-indicator.js';`<small>
+<br>exports *FuroUiBusyIndicator* js
+<br>extends *src/furo-ui5-busy-indicator.js*</small>
 
-> **Summary:** data textarea input field
-
-{{% api "_-head.md" %}}
+> **Summary:** ui5 busy indicator with methods
 
 ## Description
 
-The 'furo-ui5-textarea-input' component allows the user to enter and edit texts with data binding.
-
-It supports all features from the [SAP ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
-
-You can bind any `string` type, like `furo.fat.String` type or the `google.protobuf.StringValue` type.
+The furo-ui5-busy-indicator signals that some operation is going on and that the user must wait.
 
 ```html
- <furo-ui5-textarea-input
-    ƒ-bind-data="--daoCountry(*.data.name)"
- ></furo-ui5-textarea-input>
+<furo-ui5-busy-indicator></furo-ui5-busy-indicator>
 ```
 
-### Specificity
-1. Attributes which are set in the html source will have the highest specificity and will never get overwritten by metas or fat.
-2. Attributes set in meta will have the lowest specificity and will be overwritten by attributes from fat.
+https://sap.github.io/ui5-webcomponents/playground/components/BusyIndicator/
 
-** meta 	<  fat 	< html 	**
-
-## supported FAT attributes
- - **"readonly":"true"** set the element to readonly
- - **"required":"true"** set the element to required
- - **"disabled":"true"** set the element to disabled
- - **"placeholder":"string"** set the placeholder for the element
- - **"rows":"number"** set the number of rows.
- - **"growing":"true"** Enables the ui5-textarea to automatically grow and shrink dynamically with its content.
- - **"show-exceeded-text":"true"** if set to true. the characters exceeding the maxlength value are selected on paste and the counter below the ui5-textarea displays their number. If set to false, the user is not allowed to enter more characters than what is set in the maxlength property.
- - **"growing-max-lines":"number"** Defines the maximum number of lines that the Web Component can grow.
- - **"max":"number"** set the maximum number of characters available in the input field.
-
-## supported meta and constraints
-- **readonly: true** , set the element to readonly
-- **placeholder:"some string"** set the placeholder for the element
-- **max:"number"** set the maximum number of characters available in the input field.
-
-The constraint **required** will mark the element as required
-
-## Methods
-**bind-data(fieldNode)**
-Bind a entity field. You can use the entity even when no data was received.
-
-When you use @-object-ready from a furo-ui5-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
-
-{{% api "_-description.md" %}}
-
+{{% api "_-head.md" %}}
 
 ## Attributes and Properties
 {{% api "_-properties.md" %}}
 
 
 
-### **nativeInputAttributes**
-</small>
 
 
-<br><br>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-### **value**
-default: **&#39;&#39;**</small>
-
-
-<br><br>
-
-### **_previousValueState**
-default: **{ state: &#39;None&#39;, message: &#39;&#39; }**</small>
-
-
-<br><br>
-
-### **_attributesFromFNA**
-default: **{
-      readonly: undefined,
-      placeholder: undefined,
-    }**</small>
-
-
-<br><br>
-
-### **_constraintsFromFNA**
-default: **{
-      required: undefined,
-      max: undefined, // maps to maxlength
-    }**</small>
-
-
-<br><br>
-
-### **_labelsFromFAT**
-default: **{
-      readonly: undefined,
-      disabled: undefined,
-      required: undefined,
-    }**</small>
-
-
-<br><br>
-
-### **_attributesFromFAT**
-default: **{
-      placeholder: undefined,
-      max: undefined, // maps to maxlength
-      rows: undefined,
-      growing: undefined,
-      growingMaxLines: undefined,
-      showExceededText: undefined,
-    }**</small>
-
-
-<br><br>
-
-### **_privilegedAttributes**
-default: **{
-      readonly: null,
-      placeholder: null,
-      required: null,
-      disabled: null,
-      maxlength: null,
-      rows: null,
-      growing: null,
-      growingMaxLines: null,
-      showExceededText: null,
-    }**</small>
-
-
-<br><br>
-## Events
-{{% api "_-events.md" %}}
-
-### **change**
-<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-change</span>
-→ <small>``text``</small>
-
- Fired when the input operation has finished by pressing Enter or on focusout.
-<br><br>
-### **input**
-<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-input</span>
-→ <small>``</small>
-
- Fired when the value of the ui5-input changes at each keystroke.
-<br><br>
-### **xxxx**
-<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-xxxx</span>
-→ <small>``</small>
-
- All events from the [ui5 Input element](https://sap.github.io/ui5-webcomponents/playground/components/Input/).
-<br><br>
-### **value-changed**
-<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-value-changed</span>
-→ <small>`String`</small>
-
-Fires the field value when it changes.
-<br><br>
 
 ## Methods
 {{% api "_-methods.md" %}}
 
 
-
-### **readAttributes**
-<small>**readAttributes**() ⟹ `void`</small>
+### **activate**
+<small>**activate**() ⟹ `void`</small>
 
 <small>`*`</small> →
-<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-read-attributes</span>
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-activate</span>
 
-Reads the attributes which are set on the component dom.
-those attributes can be set. `value-state`, `value-state-message`,  `placeholder`, `required`,`readonly`,`disabled`
-Use this after manual or scripted update of the attributes.
+Sets the busy indicator state to active
 
 <br><br>
 
+### **deactivate**
+<small>**deactivate**() ⟹ `void`</small>
 
+<small>`*`</small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-deactivate</span>
 
+Sets the busy indicator state to inactive
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+<br><br>
 
 
 

--- a/hugo/content/docs/components/Events.md
+++ b/hugo/content/docs/components/Events.md
@@ -6,7 +6,7 @@ weight: 100
 
 # Events
 
-**@furo/components** <small>v1.0.0-rc.24</small>
+**@furo/components** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/components/src/src/lib/Events.js';`<small>
 <br>exports *Events* js</small>
 

--- a/hugo/content/docs/components/MediaSize.md
+++ b/hugo/content/docs/components/MediaSize.md
@@ -6,7 +6,7 @@ weight: 100
 
 # MediaSize
 
-**@furo/components** <small>v1.0.0-rc.24</small>
+**@furo/components** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/components/src/src/lib/MediaSize.js';`<small>
 <br>exports *MediaSize* js</small>
 

--- a/hugo/content/docs/components/Ui5LabelDataBinding.md
+++ b/hugo/content/docs/components/Ui5LabelDataBinding.md
@@ -6,7 +6,7 @@ weight: 100
 
 # Ui5LabelDataBinding
 
-**@furo/components** <small>v1.0.0-rc.24</small>
+**@furo/components** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/components/src/src/lib/Ui5LabelDataBinding.js';`<small>
 <br>exports *Ui5LabelDataBinding* js</small>
 

--- a/hugo/content/docs/components/_components-inside.md
+++ b/hugo/content/docs/components/_components-inside.md
@@ -7,7 +7,6 @@ bookHidden: true
 ### Components
 
 - [furo-ui5-bool-icon](furo-ui5-bool-icon.md) Displays a icon for a boolean value
-- [furo-ui5-busy-indicator](furo-ui5-busy-indicator.md) ui5 busy indicator with methods
 - [furo-ui5-button](furo-ui5-button.md) ui5 button with methods
 - [furo-ui5-card](furo-ui5-card.md) Ui5 card with data bindings
 - [furo-ui5-chart-display](furo-ui5-chart-display.md) Display charts with data objects
@@ -48,6 +47,7 @@ bookHidden: true
 - [furo-ui5-property](furo-ui5-property.md) ????? bind types of type any
 - [furo-ui5-typerenderer-labeled](furo-ui5-typerenderer-labeled.md) 
 - [furo-ui5-radio-button](furo-ui5-radio-button.md) boolean toggle button
+- [furo-ui5-rating-indicator](furo-ui5-rating-indicator.md) data rating input field
 - [furo-ui5-reference-search](furo-ui5-reference-search.md) labeled input field
 - [furo-ui5-reference-search](furo-ui5-reference-search.md) furo ui5 data reference search
 - [furo-ui5-segmented-button](furo-ui5-segmented-button.md) segmented button

--- a/hugo/content/docs/components/_index.md
+++ b/hugo/content/docs/components/_index.md
@@ -6,7 +6,7 @@ weight: 100
 ---
 
 # @furo/ui5
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 SAP UI5 Web Components data bindings for furo
 
 {{% api "_components-head.md" %}}

--- a/hugo/content/docs/components/furo-ui5-bool-icon.md
+++ b/hugo/content/docs/components/furo-ui5-bool-icon.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-bool-icon
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-bool-icon.js';`<small>
 <br>exports `<furo-ui5-bool-icon>` custom-element-definition
 <br>superclass *LitElement*

--- a/hugo/content/docs/components/furo-ui5-button.md
+++ b/hugo/content/docs/components/furo-ui5-button.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-button
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-button.js';`<small>
 <br>exports *FuroUi5Button* js
 <br>exports `<furo-ui5-button>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-card.md
+++ b/hugo/content/docs/components/furo-ui5-card.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-card
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-card.js';`<small>
 <br>exports *FuroUi5Card* js
 <br>exports `<furo-ui5-card>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-chart-display.md
+++ b/hugo/content/docs/components/furo-ui5-chart-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-chart-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-chart-display.js';`<small>
 <br>exports `<furo-ui5-chart-display>` custom-element-definition
 <br>superclass *LitElement*

--- a/hugo/content/docs/components/furo-ui5-chart.md
+++ b/hugo/content/docs/components/furo-ui5-chart.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-chart
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-chart.js';`<small>
 <br>exports `<furo-ui5-chart>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/components/furo-ui5-checkbox-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-checkbox-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-checkbox-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-checkbox-input-labeled.js';`<small>
 <br>exports *FuroUi5CheckboxInputLabeled* js
 <br>exports `<furo-ui5-checkbox-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-checkbox-input.md
+++ b/hugo/content/docs/components/furo-ui5-checkbox-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-checkbox-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-checkbox-input.js';`<small>
 <br>exports *FuroUi5CheckboxInput* js
 <br>extends *src/furo-ui5-checkbox-input.js*
@@ -70,6 +70,8 @@ The constraint **required** will mark the element as required.
 
 
 
+
+
 ## Events
 {{% api "_furo-ui5-checkbox-input-events.md" %}}
 
@@ -89,6 +91,26 @@ Fires the field value when it changes.
 ## Methods
 {{% api "_furo-ui5-checkbox-input-methods.md" %}}
 
+
+### **check**
+<small>**check**() ⟹ `void`</small>
+
+<small>`*`</small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-check</span>
+
+Checks the checkbox and updates the value
+
+<br><br>
+
+### **uncheck**
+<small>**uncheck**() ⟹ `void`</small>
+
+<small>`*`</small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-uncheck</span>
+
+Unhecks the checkbox and updates the value
+
+<br><br>
 
 ### **bindData**
 <small>**bindData**(*fieldNode* `FieldNode` ) ⟹ `void`</small>

--- a/hugo/content/docs/components/furo-ui5-combobox-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-combobox-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-combobox-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-combobox-labeled.js';`<small>
 <br>exports *FuroUi5ComboboxLabeled* js
 <br>exports `<furo-ui5-combobox-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-combobox.md
+++ b/hugo/content/docs/components/furo-ui5-combobox.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-combobox
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-combobox.js';`<small>
 <br>exports *FuroUi5Combobox* js
 <br>extends *src/furo-ui5-combobox.js*

--- a/hugo/content/docs/components/furo-ui5-context-menu-display.md
+++ b/hugo/content/docs/components/furo-ui5-context-menu-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-context-menu-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-context-menu-display.js';`<small>
 <br>exports *FuroUi5ContextMenuDisplay* js
 <br>exports `<furo-ui5-context-menu-display>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-context-menu-item.md
+++ b/hugo/content/docs/components/furo-ui5-context-menu-item.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-context-menu-item
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/subcomponents/furo-ui5-context-menu-item.js';`<small>
 <br>exports *FuroUi5ContextMenuItem* js
 <br>exports `<furo-ui5-context-menu-item>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-context-menu.md
+++ b/hugo/content/docs/components/furo-ui5-context-menu.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-context-menu
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-context-menu.js';`<small>
 <br>exports *FuroUi5ContextMenu* js
 <br>exports `<furo-ui5-context-menu>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-context-submenu.md
+++ b/hugo/content/docs/components/furo-ui5-context-submenu.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-context-submenu
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/subcomponents/furo-ui5-context-submenu.js';`<small>
 <br>exports *FuroUi5ContextSubmenu* js
 <br>exports `<furo-ui5-context-submenu>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-date-picker-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-date-picker-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-date-picker-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-date-picker-labeled.js';`<small>
 <br>exports *FuroUi5DatePickerLabeled* js
 <br>exports `<furo-ui5-date-picker-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-date-picker.md
+++ b/hugo/content/docs/components/furo-ui5-date-picker.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-date-picker
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-date-picker.js';`<small>
 <br>exports *FuroUi5DatePicker* js
 <br>extends *src/furo-ui5-date-picker.js*

--- a/hugo/content/docs/components/furo-ui5-date-time-picker-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-date-time-picker-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-date-time-picker-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-date-time-picker-labeled.js';`<small>
 <br>exports *FuroUi5DateTimePickerLabeled* js
 <br>exports `<furo-ui5-date-time-picker-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-date-time-picker.md
+++ b/hugo/content/docs/components/furo-ui5-date-time-picker.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-date-time-picker
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-date-time-picker.js';`<small>
 <br>exports *FuroUi5DateTimePicker* js
 <br>extends *src/furo-ui5-date-time-picker.js*

--- a/hugo/content/docs/components/furo-ui5-dialog-display.md
+++ b/hugo/content/docs/components/furo-ui5-dialog-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-dialog-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-dialog-display.js';`<small>
 <br>exports `<furo-ui5-dialog-display>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/components/furo-ui5-dialog.md
+++ b/hugo/content/docs/components/furo-ui5-dialog.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-dialog
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-dialog.js';`<small>
 <br>exports *FuroUi5Dialog* js
 <br>extends *src/furo-ui5-dialog.js*</small>

--- a/hugo/content/docs/components/furo-ui5-flexible-grid.md
+++ b/hugo/content/docs/components/furo-ui5-flexible-grid.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-flexible-grid
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-flexible-grid.js';`<small>
 <br>exports `<furo-ui5-flexible-grid>` custom-element-definition
 <br>superclass *LitElement*

--- a/hugo/content/docs/components/furo-ui5-form-field-container.md
+++ b/hugo/content/docs/components/furo-ui5-form-field-container.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-form-field-container
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-form-field-container.js';`<small>
 <br>exports *FuroUi5FormFieldContainer* js
 <br>exports `<furo-ui5-form-field-container>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-header-panel.md
+++ b/hugo/content/docs/components/furo-ui5-header-panel.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-header-panel
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-header-panel.js';`<small>
 <br>exports *FuroUi5HeaderPanel* js
 <br>exports `<furo-ui5-header-panel>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-markdown.md
+++ b/hugo/content/docs/components/furo-ui5-markdown.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-markdown
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-markdown.js';`<small>
 <br>exports `<furo-ui5-markdown>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/components/furo-ui5-message-strip-display.md
+++ b/hugo/content/docs/components/furo-ui5-message-strip-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-message-strip-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-message-strip-display.js';`<small>
 <br>exports *FuroUi5MessageStripDisplay* js
 <br>exports `<furo-ui5-message-strip-display>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-message-strip.md
+++ b/hugo/content/docs/components/furo-ui5-message-strip.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-message-strip
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-message-strip.js';`<small>
 <br>exports *FuroUi5MessageStrip* js
 <br>exports `<furo-ui5-message-strip>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-money-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-money-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-money-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-money-input-labeled.js';`<small>
 <br>exports *FuroUi5MoneyInputLabeled* js
 <br>exports `<furo-ui5-money-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-money-input.md
+++ b/hugo/content/docs/components/furo-ui5-money-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-money-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-money-input.js';`<small>
 <br>exports *FuroUi5MoneyInput* js
 <br>exports `<furo-ui5-money-input>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-multi-combobox-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-multi-combobox-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-multi-combobox-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-multi-combobox-labeled.js';`<small>
 <br>exports *FuroUi5MultiComboboxLabeled* js
 <br>exports `<furo-ui5-multi-combobox-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-multi-combobox.md
+++ b/hugo/content/docs/components/furo-ui5-multi-combobox.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-multi-combobox
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-multi-combobox.js';`<small>
 <br>exports *FuroUi5MultiCombobox* js
 <br>extends *src/furo-ui5-multi-combobox.js*

--- a/hugo/content/docs/components/furo-ui5-multi-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-multi-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-multi-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-multi-input-labeled.js';`<small>
 <br>exports *FuroUi5MultiInputLabeled* js
 <br>exports `<furo-ui5-multi-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-multi-input.md
+++ b/hugo/content/docs/components/furo-ui5-multi-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-multi-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-multi-input.js';`<small>
 <br>exports *FuroUi5MultiInput* js
 <br>extends *src/furo-ui5-multi-input.js*

--- a/hugo/content/docs/components/furo-ui5-notification-group-display.md
+++ b/hugo/content/docs/components/furo-ui5-notification-group-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-notification-group-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-notification-group-display.js';`<small>
 <br>exports *FuroUi5NotificationGroupDisplay* js
 <br>exports `<furo-ui5-notification-group-display>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-notification-list-display.md
+++ b/hugo/content/docs/components/furo-ui5-notification-list-display.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-notification-list-display
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-notification-list-display.js';`<small>
 <br>exports *FuroUi5NotificationListDisplay* js
 <br>exports `<furo-ui5-notification-list-display>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-notification.md
+++ b/hugo/content/docs/components/furo-ui5-notification.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-notification
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-notification.js';`<small>
 <br>exports *FuroUi5Notification* js
 <br>exports `<furo-ui5-notification>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-number-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-number-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-number-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-number-input-labeled.js';`<small>
 <br>exports *FuroUi5NumberInputLabeled* js
 <br>exports `<furo-ui5-number-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-number-input.md
+++ b/hugo/content/docs/components/furo-ui5-number-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-number-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-step-input.js';`<small>
 <br>exports *FuroUi5StepInput* js
 <br>extends *src/furo-ui5-step-input.js*

--- a/hugo/content/docs/components/furo-ui5-pagination-bar.md
+++ b/hugo/content/docs/components/furo-ui5-pagination-bar.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-pagination-bar
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-pagination-bar.js';`<small>
 <br>exports *FuroUi5PaginationBar* js
 <br>exports `<furo-ui5-pagination-bar>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-password-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-password-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-password-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-password-input-labeled.js';`<small>
 <br>exports *FuroUi5PasswordInputLabeled* js
 <br>exports `<furo-ui5-password-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-password-input.md
+++ b/hugo/content/docs/components/furo-ui5-password-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-password-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-password-input.js';`<small>
 <br>exports *FuroUi5PasswordInput* js
 <br>extends *src/furo-ui5-password-input.js*

--- a/hugo/content/docs/components/furo-ui5-progress-indicator.md
+++ b/hugo/content/docs/components/furo-ui5-progress-indicator.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-progress-indicator
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-progress-indicator.js';`<small>
 <br>exports *FuroUi5ProgressIndicator* js
 <br>extends *src/furo-ui5-progress-indicator.js*

--- a/hugo/content/docs/components/furo-ui5-property.md
+++ b/hugo/content/docs/components/furo-ui5-property.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-property
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-property.js';`<small>
 <br>exports *FuroUi5Property* js
 <br>exports `<furo-ui5-property>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-radio-button.md
+++ b/hugo/content/docs/components/furo-ui5-radio-button.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-radio-button
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-radio-button.js';`<small>
 <br>exports *FuroUi5RadioButton* js
 <br>extends *src/furo-ui5-radio-button.js*

--- a/hugo/content/docs/components/furo-ui5-rating-indicator.md
+++ b/hugo/content/docs/components/furo-ui5-rating-indicator.md
@@ -1,0 +1,127 @@
+---
+title: furo-ui5-rating-indicator
+description: data rating input field
+weight: 50
+---
+
+# furo-ui5-rating-indicator
+**@furo/ui5** <small>v1.0.0-rc.25</small>
+<br>`import '@furo/ui5/src/furo-ui5-rating-indicator.js';`<small>
+<br>exports *FuroUi5RatingIndicator* js
+<br>extends *src/furo-ui5-rating-indicator.js*
+<br> mixes *FieldNodeAdapter*</small>
+
+> **Summary:** data rating input field
+
+## Description
+
+The furo-ui5-rating-indicator  is used to display a specific number of icons that are used to rate an item.
+Additionally, it is also used to display the average and overall ratings.
+https://sap.github.io/ui5-webcomponents/playground/components/RatingIndicator/
+
+You can bind any `number` type, any `furo.fat.xxx` number type, `furo.BigDecimal` or the `google.wrapper.xxx` number types.
+
+```html
+ <furo-ui5-rating-indicator
+    ƒ-bind-data="--dao(FIELDNODE)"
+ ></furo-ui5-rating-indicator>
+```
+
+### Specificity
+1. Attributes which are set in the html source will have the highest specificity and will never get overwritten by metas or fat.
+2. Attributes set in meta will have the lowest specificity and will be overwritten by attributes from fat.
+
+| meta  | fat  | html  |
+|------  |-----  |------  |
+| 1      | 10    | 100    |
+
+
+## supported FAT attributes
+ - **"readonly":"true"** set the element to readonly
+ - **"disabled":"true"** set the element to disabled
+
+## supported meta and constraints
+- **readonly: true** , set the element to readonly
+
+## Methods
+**bind-data(fieldNode)**
+Bind aa entity field. You can use the entity even when no data was received.
+
+When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
+
+{{% api "_furo-ui5-rating-indicator-head.md" %}}
+
+## Attributes and Properties
+{{% api "_furo-ui5-rating-indicator-properties.md" %}}
+
+
+
+
+
+
+
+
+
+
+
+## Events
+{{% api "_furo-ui5-rating-indicator-events.md" %}}
+
+### **change**
+<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-change</span>
+→ <small>``number``</small>
+
+ Fired when the values changes.
+<br><br>
+### **furo-value-changed**
+<span  style="border-width:2px 10px 2px 2px; border-style: solid;border-color:  rgb(2, 168, 244);font-family:monospace; padding:2px 4px;">@-furo-value-changed</span>
+→ <small>``number``</small>
+
+Fires the field value when it changes.
+<br><br>
+
+## Methods
+{{% api "_furo-ui5-rating-indicator-methods.md" %}}
+
+
+### **readAttributes**
+<small>**readAttributes**() ⟹ `void`</small>
+
+<small>`*`</small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-read-attributes</span>
+
+Reads the attributes which are set on the component dom.
+those attributes can be set. `readonly`,`disabled`
+Use this after manual or scripted update of the attributes.
+
+<br><br>
+
+
+### **bindData**
+<small>**bindData**(*fieldNode* `FieldNode` ) ⟹ `void`</small>
+
+<small>`FieldNode` </small> →
+<span  style="border-width:2px 2px 2px 10px; border-style: solid;border-color:  rgb(76, 175, 80);font-family:monospace; padding:2px 4px;">ƒ-bind-data</span>
+
+Binds a FieldNode to the component.
+
+Supported types:
+- `double`, `float`, `int32`, `uint32`, `sint32`, `fixed32`, `sfixed32`, `int64`, `uint64`, `sint64`, `fixed64`, `sfixed64`
+- `google.protobuf.DoubleValue`, `google.protobuf.FloatValue`, `google.protobuf.Int32Value`, etc.
+- `furo.fat.Doube`, `furo.fat.Float`, `furo.fat.Int32`, etc.
+- `furo.BigDecimal`
+
+- <small>fieldNode </small>
+<br><br>
+
+
+
+
+
+
+
+
+
+
+{{% api "_furo-ui5-rating-indicator-footer.md" %}}
+{{% api "_furo-ui5-rating-indicator-scripts.md" %}}

--- a/hugo/content/docs/components/furo-ui5-reference-search.md
+++ b/hugo/content/docs/components/furo-ui5-reference-search.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-reference-search
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-reference-search.js';`<small>
 <br>exports *FuroUi5ReferenceSearch* js
 <br>exports `<furo-ui5-reference-search>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-segmented-button.md
+++ b/hugo/content/docs/components/furo-ui5-segmented-button.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-segmented-button
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-segmented-button.js';`<small>
 <br>exports *FuroUi5SegmentedButton* js
 <br>extends *src/furo-ui5-segmented-button.js*

--- a/hugo/content/docs/components/furo-ui5-select-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-select-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-select-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-select-labeled.js';`<small>
 <br>exports *FuroUi5SelectLabeled* js
 <br>exports `<furo-ui5-select-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-select.md
+++ b/hugo/content/docs/components/furo-ui5-select.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-select
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-select.js';`<small>
 <br>exports *FuroUi5Select* js
 <br>extends *src/furo-ui5-select.js*

--- a/hugo/content/docs/components/furo-ui5-sign-pad.md
+++ b/hugo/content/docs/components/furo-ui5-sign-pad.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-sign-pad
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-sign-pad.js';`<small>
 <br>exports *FuroUi5SignPad* js
 <br>exports `<furo-ui5-sign-pad>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-step-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-step-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-step-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-step-input-labeled.js';`<small>
 <br>exports *FuroUi5StepInputLabeled* js
 <br>exports `<furo-ui5-step-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-table-row.md
+++ b/hugo/content/docs/components/furo-ui5-table-row.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-table-row
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/subcomponents/furo-ui5-table-row.js';`<small>
 <br>exports *FuroUi5TableRow* js
 <br>exports `<furo-ui5-table-row>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-table.md
+++ b/hugo/content/docs/components/furo-ui5-table.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-table
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-table.js';`<small>
 <br>exports *FuroUi5Table* js
 <br>exports `<furo-ui5-table>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-text-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-text-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-text-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-text-input-labeled.js';`<small>
 <br>exports *FuroUi5TextInputLabeled* js
 <br>exports `<furo-ui5-text-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-text-input.md
+++ b/hugo/content/docs/components/furo-ui5-text-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-text-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-text-input.js';`<small>
 <br>exports *FuroUi5TextInput* js
 <br>extends *src/furo-ui5-text-input.js*

--- a/hugo/content/docs/components/furo-ui5-textarea-input-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-textarea-input-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-textarea-input-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-textarea-input-labeled.js';`<small>
 <br>exports *FuroUi5TextareaInputLabeled* js
 <br>exports `<furo-ui5-textarea-input-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-textarea-input.md
+++ b/hugo/content/docs/components/furo-ui5-textarea-input.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-textarea-input
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-textarea-input.js';`<small>
 <br>exports *FuroUi5TextareaInput* js
 <br>extends *src/furo-ui5-textarea-input.js*

--- a/hugo/content/docs/components/furo-ui5-time-picker-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-time-picker-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-time-picker-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-time-picker-labeled.js';`<small>
 <br>exports *FuroUi5TimePickerLabeled* js
 <br>exports `<furo-ui5-time-picker-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-time-picker.md
+++ b/hugo/content/docs/components/furo-ui5-time-picker.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-time-picker
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-time-picker.js';`<small>
 <br>exports *FuroUi5TimePicker* js
 <br>extends *src/furo-ui5-time-picker.js*

--- a/hugo/content/docs/components/furo-ui5-toggle-button.md
+++ b/hugo/content/docs/components/furo-ui5-toggle-button.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-toggle-button
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-toggle-button.js';`<small>
 <br>exports *FuroUi5ToggleButton* js
 <br>extends *src/furo-ui5-toggle-button.js*

--- a/hugo/content/docs/components/furo-ui5-tree-item.md
+++ b/hugo/content/docs/components/furo-ui5-tree-item.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-tree-item
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/subcomponents/furo-ui5-tree-item.js';`<small>
 <br>exports *FuroUi5TreeItem* js
 <br>exports `<furo-ui5-tree-item>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-tree.md
+++ b/hugo/content/docs/components/furo-ui5-tree.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-tree
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-tree.js';`<small>
 <br>exports *FuroUi5Tree* js
 <br>exports `<furo-ui5-tree>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-typerenderer-labeled.md
+++ b/hugo/content/docs/components/furo-ui5-typerenderer-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-typerenderer-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-typerenderer-labeled.js';`<small>
 <br>exports *FuroUi5TyperendererLabeled* js
 <br>exports `<furo-ui5-typerenderer-labeled>` custom-element-definition

--- a/hugo/content/docs/components/furo-ui5-z-grid.md
+++ b/hugo/content/docs/components/furo-ui5-z-grid.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # furo-ui5-z-grid
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/furo-ui5-z-grid.js';`<small>
 <br>exports `<furo-ui5-z-grid>` custom-element-definition
 <br>superclass *LitElement*

--- a/hugo/content/docs/components/ui5-reference-search-item.md
+++ b/hugo/content/docs/components/ui5-reference-search-item.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # ui5-reference-search-item
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/ui5-reference-search-item.js';`<small>
 <br>exports *Ui5ReferenceSearchItem* js
 <br>exports `<ui5-reference-search-item>` custom-element-definition

--- a/hugo/content/docs/typerenderer/_index.md
+++ b/hugo/content/docs/typerenderer/_index.md
@@ -6,7 +6,7 @@ weight: 100
 ---
 
 # @furo/ui5
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 SAP UI5 Web Components data bindings for furo
 
 {{% api "_typerenderer-head.md" %}}

--- a/hugo/content/docs/typerenderer/cell-bool.md
+++ b/hugo/content/docs/typerenderer/cell-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-bool.js';`<small>
 <br>exports *CellBool* js
 <br>exports `<cell-bool>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-double.md
+++ b/hugo/content/docs/typerenderer/cell-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-double.js';`<small>
 <br>exports *CellDouble* js
 <br>exports `<cell-double>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-bigdecimal.md
+++ b/hugo/content/docs/typerenderer/cell-furo-bigdecimal.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-bigdecimal
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-bigdecimal.js';`<small>
 <br>exports `<cell-furo-bigdecimal>` custom-element-definition
 <br>extends */src/typerenderer/cell-float.js*

--- a/hugo/content/docs/typerenderer/cell-furo-fat-bool.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-bool.js';`<small>
 <br>exports `<cell-furo-fat-bool>` custom-element-definition
 <br>extends */src/typerenderer/cell-bool.js*

--- a/hugo/content/docs/typerenderer/cell-furo-fat-double.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-double.js';`<small>
 <br>exports `<cell-furo-fat-double>` custom-element-definition
 <br>extends */src/typerenderer/cell-double.js*

--- a/hugo/content/docs/typerenderer/cell-furo-fat-float.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-float.js';`<small>
 <br>exports `<cell-furo-fat-float>` custom-element-definition
 <br>extends */src/typerenderer/cell-float.js*

--- a/hugo/content/docs/typerenderer/cell-furo-fat-int32.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-int32.js';`<small>
 <br>exports *CellFuroFatInt32* js
 <br>exports `<cell-furo-fat-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-fat-int64.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-int64.js';`<small>
 <br>exports *CellFuroFatInt64* js
 <br>exports `<cell-furo-fat-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-fat-string.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-string.js';`<small>
 <br>exports `<cell-furo-fat-string>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-furo-fat-uint32.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-uint32.js';`<small>
 <br>exports `<cell-furo-fat-uint32>` custom-element-definition
 <br>extends */src/typerenderer/cell-furo-fat-int32.js*

--- a/hugo/content/docs/typerenderer/cell-furo-fat-uint64.md
+++ b/hugo/content/docs/typerenderer/cell-furo-fat-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-fat-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-fat-uint64.js';`<small>
 <br>exports `<cell-furo-fat-uint64>` custom-element-definition
 <br>extends */src/typerenderer/cell-furo-fat-int64.js*

--- a/hugo/content/docs/typerenderer/cell-furo-integerproperty.md
+++ b/hugo/content/docs/typerenderer/cell-furo-integerproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-integerproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-integerproperty.js';`<small>
 <br>exports *CellFuroIntegerproperty* js
 <br>exports `<cell-furo-integerproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-link.md
+++ b/hugo/content/docs/typerenderer/cell-furo-link.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-link
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-link.js';`<small>
 <br>exports `<cell-furo-link>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-furo-numberproperty.md
+++ b/hugo/content/docs/typerenderer/cell-furo-numberproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-numberproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-numberproperty.js';`<small>
 <br>exports *CellFuroNumberproperty* js
 <br>exports `<cell-furo-numberproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-property-repeated.md
+++ b/hugo/content/docs/typerenderer/cell-furo-property-repeated.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-property-repeated
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-property-repeated.js';`<small>
 <br>exports *CellFuroPropertyRepeated* js
 <br>exports `<cell-furo-property-repeated>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-property.md
+++ b/hugo/content/docs/typerenderer/cell-furo-property.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-property
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-property.js';`<small>
 <br>exports *CellFuroProperty* js
 <br>exports `<cell-furo-property>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-reference.md
+++ b/hugo/content/docs/typerenderer/cell-furo-reference.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-reference
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-reference.js';`<small>
 <br>exports `<cell-furo-reference>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-furo-stringoptionproperty.md
+++ b/hugo/content/docs/typerenderer/cell-furo-stringoptionproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-stringoptionproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-stringoptionproperty.js';`<small>
 <br>exports *CellFuroStringoptionproperty* js
 <br>exports `<cell-furo-stringoptionproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-stringproperty.md
+++ b/hugo/content/docs/typerenderer/cell-furo-stringproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-stringproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-stringproperty.js';`<small>
 <br>exports *CellFuroStringproperty* js
 <br>exports `<cell-furo-stringproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-furo-type-date.md
+++ b/hugo/content/docs/typerenderer/cell-furo-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-type-date.js';`<small>
 <br>exports `<cell-furo-type-date>` custom-element-definition
 <br>extends */src/typerenderer/cell-google-type-date.js*

--- a/hugo/content/docs/typerenderer/cell-furo-type-money.md
+++ b/hugo/content/docs/typerenderer/cell-furo-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-furo-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-furo-type-money.js';`<small>
 <br>exports `<cell-furo-type-money>` custom-element-definition
 <br>extends */src/typerenderer/cell-google-type-money.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-floatvalue.js';`<small>
 <br>exports `<cell-google-protobuf-floatvalue>` custom-element-definition
 <br>extends */src/typerenderer/cell-float.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-any.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-any.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-any
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-any.js';`<small>
 <br>exports `<cell-google-protobuf-any>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-boolvalue.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-boolvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-boolvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-boolvalue.js';`<small>
 <br>exports `<cell-google-protobuf-boolvalue>` custom-element-definition
 <br>extends */src/typerenderer/cell-bool.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-doublevalue.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-doublevalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-doublevalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-doublevalue.js';`<small>
 <br>exports `<cell-google-protobuf-doublevalue>` custom-element-definition
 <br>extends */src/typerenderer/cell-double.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-int32value.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-int32value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-int32value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-int32value.js';`<small>
 <br>exports `<cell-google-protobuf-int32value>` custom-element-definition
 <br>extends */src/typerenderer/cell-int32.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-int64value.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-int64value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-int64value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-int64value.js';`<small>
 <br>exports `<cell-google-protobuf-int64value>` custom-element-definition
 <br>extends */src/typerenderer/cell-int64.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-stringvalue.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-stringvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-stringvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-stringvalue.js';`<small>
 <br>exports `<cell-google-protobuf-stringvalue>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-timestamp.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-timestamp.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-timestamp
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-timestamp.js';`<small>
 <br>exports `<cell-google-protobuf-timestamp>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-uint32value.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-uint32value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-uint32value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-uint32value.js';`<small>
 <br>exports `<cell-google-protobuf-uint32value>` custom-element-definition
 <br>extends */src/typerenderer/cell-uint32.js*

--- a/hugo/content/docs/typerenderer/cell-google-protobuf-uint64value.md
+++ b/hugo/content/docs/typerenderer/cell-google-protobuf-uint64value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-protobuf-uint64value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-protobuf-uint64value.js';`<small>
 <br>exports `<cell-google-protobuf-uint64value>` custom-element-definition
 <br>extends */src/typerenderer/cell-uint64.js*

--- a/hugo/content/docs/typerenderer/cell-google-type-color.md
+++ b/hugo/content/docs/typerenderer/cell-google-type-color.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-type-color
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-type-color.js';`<small>
 <br>exports `<cell-google-type-color>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-google-type-date.md
+++ b/hugo/content/docs/typerenderer/cell-google-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-type-date.js';`<small>
 <br>exports *CellGoogleTypeDate* js
 <br>exports `<cell-google-type-date>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-google-type-money.md
+++ b/hugo/content/docs/typerenderer/cell-google-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-type-money.js';`<small>
 <br>exports *CellGoogleTypeMoney* js
 <br>exports `<cell-google-type-money>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-google-type-timeofday.md
+++ b/hugo/content/docs/typerenderer/cell-google-type-timeofday.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-google-type-timeofday
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-google-type-timeofday.js';`<small>
 <br>exports `<cell-google-type-timeofday>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/cell-int32.md
+++ b/hugo/content/docs/typerenderer/cell-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-int32.js';`<small>
 <br>exports *CellInt32* js
 <br>exports `<cell-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-int64.md
+++ b/hugo/content/docs/typerenderer/cell-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-int64.js';`<small>
 <br>exports *CellInt64* js
 <br>exports `<cell-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-string.md
+++ b/hugo/content/docs/typerenderer/cell-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-string.js';`<small>
 <br>exports *CellString* js
 <br>exports `<cell-string>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-uint32.md
+++ b/hugo/content/docs/typerenderer/cell-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-uint32.js';`<small>
 <br>exports *CellUint32* js
 <br>exports `<cell-uint32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell-uint64.md
+++ b/hugo/content/docs/typerenderer/cell-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-uint64.js';`<small>
 <br>exports *CellUint64* js
 <br>exports `<cell-uint64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/cell.md
+++ b/hugo/content/docs/typerenderer/cell.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # cell
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/cell-float.js';`<small>
 <br>exports *CellFloat* js
 <br>exports `<cell-float>` custom-element-definition

--- a/hugo/content/docs/typerenderer/celledit-bool.md
+++ b/hugo/content/docs/typerenderer/celledit-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-bool.js';`<small>
 <br>exports *CelleditBool* js
 <br>extends */src/furo-ui5-checkbox-input.js*

--- a/hugo/content/docs/typerenderer/celledit-double.md
+++ b/hugo/content/docs/typerenderer/celledit-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-double.js';`<small>
 <br>exports *CelleditDouble* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-float.md
+++ b/hugo/content/docs/typerenderer/celledit-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-float.js';`<small>
 <br>exports *CelleditFloat* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-furo-bigdecimal.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-bigdecimal.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-bigdecimal
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-bigdecimal.js';`<small>
 <br>exports *CelleditFuroBigdecimal* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-furo-fat-int32.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-fat-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-fat-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-fat-int32.js';`<small>
 <br>exports *CelleditFuroFatInt32* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-furo-fat-int64.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-fat-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-fat-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-fat-int64.js';`<small>
 <br>exports *CelleditFuroFatInt64* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-furo-link.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-link.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-link
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-link.js';`<small>
 <br>exports `<celledit-furo-link>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/celledit-furo-property-repeated.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-property-repeated.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-property-repeated
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-property-repeated.js';`<small>
 <br>exports *CelleditFuroPropertyRepeated* js
 <br>exports `<celledit-furo-property-repeated>` custom-element-definition

--- a/hugo/content/docs/typerenderer/celledit-furo-property.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-property.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-property
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-property.js';`<small>
 <br>exports *CelleditFuroProperty* js
 <br>exports `<celledit-furo-property>` custom-element-definition

--- a/hugo/content/docs/typerenderer/celledit-furo-reference.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-reference.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-reference
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-reference.js';`<small>
 <br>exports *CelleditFuroReference* js
 <br>exports `<celledit-furo-reference>` custom-element-definition

--- a/hugo/content/docs/typerenderer/celledit-furo-type-money.md
+++ b/hugo/content/docs/typerenderer/celledit-furo-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-furo-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-furo-type-money.js';`<small>
 <br>exports `<celledit-furo-type-money>` custom-element-definition
 <br>extends */src/furo-ui5-money-input.js*

--- a/hugo/content/docs/typerenderer/celledit-google-protobuf-any.md
+++ b/hugo/content/docs/typerenderer/celledit-google-protobuf-any.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-google-protobuf-any
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-google-protobuf-any.js';`<small>
 <br>exports `<celledit-google-protobuf-any>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/celledit-google-type-money.md
+++ b/hugo/content/docs/typerenderer/celledit-google-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-google-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-google-type-money.js';`<small>
 <br>exports `<celledit-google-type-money>` custom-element-definition
 <br>extends */src/furo-ui5-money-input.js*

--- a/hugo/content/docs/typerenderer/celledit-int32.md
+++ b/hugo/content/docs/typerenderer/celledit-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-int32.js';`<small>
 <br>exports *CelleditInt32* js
 <br>extends */src/furo-ui5-number-input.js*

--- a/hugo/content/docs/typerenderer/celledit-int64.md
+++ b/hugo/content/docs/typerenderer/celledit-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-int64.js';`<small>
 <br>exports *CelleditInt64* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-string.md
+++ b/hugo/content/docs/typerenderer/celledit-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-string.js';`<small>
 <br>exports *CelleditString* js
 <br>extends */src/furo-ui5-text-input.js*

--- a/hugo/content/docs/typerenderer/celledit-uint32.md
+++ b/hugo/content/docs/typerenderer/celledit-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-uint32.js';`<small>
 <br>exports *CelleditUint32* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/celledit-uint64.md
+++ b/hugo/content/docs/typerenderer/celledit-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # celledit-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/celledit-uint64.js';`<small>
 <br>exports *CelleditUint64* js
 <br>extends */src/typerenderer/celledit-int32.js*

--- a/hugo/content/docs/typerenderer/display-bool.md
+++ b/hugo/content/docs/typerenderer/display-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-bool.js';`<small>
 <br>exports *DisplayBool* js
 <br>exports `<display-bool>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-double.md
+++ b/hugo/content/docs/typerenderer/display-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-double.js';`<small>
 <br>exports *DisplayDouble* js
 <br>exports `<display-double>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-float.md
+++ b/hugo/content/docs/typerenderer/display-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-float.js';`<small>
 <br>exports *DisplayFloat* js
 <br>exports `<display-float>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-.md
+++ b/hugo/content/docs/typerenderer/display-furo-.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-integerproperty.js';`<small>
 <br>exports *DisplayFuroIntegerproperty* js
 <br>exports `<display-furo-integerproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-bigdecimal.md
+++ b/hugo/content/docs/typerenderer/display-furo-bigdecimal.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-bigdecimal
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-bigdecimal.js';`<small>
 <br>exports *DisplayFuroBigdecimal* js
 <br>exports `<display-furo-bigdecimal>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-fat-Uint32.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-Uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-Uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-uint32.js';`<small>
 <br>exports `<display-furo-fat-uint32>` custom-element-definition
 <br>extends */src/typerenderer/display-furo-fat-int32.js*

--- a/hugo/content/docs/typerenderer/display-furo-fat-bool.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-bool.js';`<small>
 <br>exports `<display-furo-fat-bool>` custom-element-definition
 <br>extends */src/typerenderer/display-bool.js*

--- a/hugo/content/docs/typerenderer/display-furo-fat-double.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-double.js';`<small>
 <br>exports `<display-furo-fat-double>` custom-element-definition
 <br>extends */src/typerenderer/display-double.js*

--- a/hugo/content/docs/typerenderer/display-furo-fat-float.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-float.js';`<small>
 <br>exports `<display-furo-fat-float>` custom-element-definition
 <br>extends */src/typerenderer/display-float.js*

--- a/hugo/content/docs/typerenderer/display-furo-fat-int32.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-int32.js';`<small>
 <br>exports *DisplayFuroFatInt32* js
 <br>exports `<display-furo-fat-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-fat-int64.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-int64.js';`<small>
 <br>exports *DisplayFuroFatInt64* js
 <br>exports `<display-furo-fat-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-fat-string.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-string.js';`<small>
 <br>exports `<display-furo-fat-string>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-furo-fat-uint64.md
+++ b/hugo/content/docs/typerenderer/display-furo-fat-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-fat-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-fat-uint64.js';`<small>
 <br>exports `<display-furo-fat-uint64>` custom-element-definition
 <br>extends */src/typerenderer/display-furo-fat-int64.js*

--- a/hugo/content/docs/typerenderer/display-furo-link.md
+++ b/hugo/content/docs/typerenderer/display-furo-link.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-link
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-link.js';`<small>
 <br>exports `<display-furo-link>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-furo-numberproperty.md
+++ b/hugo/content/docs/typerenderer/display-furo-numberproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-numberproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-numberproperty.js';`<small>
 <br>exports *DisplayFuroNumberproperty* js
 <br>exports `<display-furo-numberproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-property-labeled.md
+++ b/hugo/content/docs/typerenderer/display-furo-property-labeled.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-property-labeled
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-property-repeats-labeled.js';`<small>
 <br>exports *DisplayFuroPropertyRepeatsLabeled* js
 <br>exports `<display-furo-property-repeats-labeled>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-property-repeated.md
+++ b/hugo/content/docs/typerenderer/display-furo-property-repeated.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-property-repeated
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-property-repeated.js';`<small>
 <br>exports *DisplayFuroPropertyRepeated* js
 <br>exports `<display-furo-property-repeated>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-property.md
+++ b/hugo/content/docs/typerenderer/display-furo-property.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-property
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-property.js';`<small>
 <br>exports *DisplayFuroProperty* js
 <br>exports `<display-furo-property>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-reference.md
+++ b/hugo/content/docs/typerenderer/display-furo-reference.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-reference
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-reference.js';`<small>
 <br>exports `<display-furo-reference>` custom-element-definition
 <br>superclass *LitElement*

--- a/hugo/content/docs/typerenderer/display-furo-stringoptionproperty.md
+++ b/hugo/content/docs/typerenderer/display-furo-stringoptionproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-stringoptionproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-stringoptionproperty.js';`<small>
 <br>exports *DisplayFuroStringoptionproperty* js
 <br>exports `<display-furo-stringoptionproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-stringproperty.md
+++ b/hugo/content/docs/typerenderer/display-furo-stringproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-stringproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-stringproperty.js';`<small>
 <br>exports *DisplayFuroStringproperty* js
 <br>exports `<display-furo-stringproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-furo-type-date.md
+++ b/hugo/content/docs/typerenderer/display-furo-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-type-date.js';`<small>
 <br>exports `<display-furo-type-date>` custom-element-definition
 <br>extends */src/typerenderer/display-google-type-date.js*

--- a/hugo/content/docs/typerenderer/display-furo-type-money.md
+++ b/hugo/content/docs/typerenderer/display-furo-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-furo-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-furo-type-money.js';`<small>
 <br>exports `<display-furo-type-money>` custom-element-definition
 <br>extends */src/typerenderer/display-google-type-money.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-any.js';`<small>
 <br>exports `<display-google-protobuf-any>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-google-protobuf-boolvalue.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-boolvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-boolvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-boolvalue.js';`<small>
 <br>exports `<display-google-protobuf-boolvalue>` custom-element-definition
 <br>extends */src/typerenderer/display-bool.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-doublevalue.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-doublevalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-doublevalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-doublevalue.js';`<small>
 <br>exports `<display-google-protobuf-doublevalue>` custom-element-definition
 <br>extends */src/typerenderer/display-double.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-floatvalue.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-floatvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-floatvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-floatvalue.js';`<small>
 <br>exports `<display-google-protobuf-floatvalue>` custom-element-definition
 <br>extends */src/typerenderer/display-float.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-int32Value.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-int32Value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-int32Value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-int32value.js';`<small>
 <br>exports `<display-google-protobuf-int32value>` custom-element-definition
 <br>extends */src/typerenderer/display-int32.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-int64Value.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-int64Value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-int64Value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-int64value.js';`<small>
 <br>exports `<display-google-protobuf-int64value>` custom-element-definition
 <br>extends */src/typerenderer/display-int64.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-stringvalue.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-stringvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-stringvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-stringvalue.js';`<small>
 <br>exports `<display-google-protobuf-stringvalue>` custom-element-definition
 <br>extends */src/typerenderer/display-string.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-timestamp.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-timestamp.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-timestamp
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-timestamp.js';`<small>
 <br>exports `<display-google-protobuf-timestamp>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-google-protobuf-uint32value.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-uint32value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-uint32value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-uint32value.js';`<small>
 <br>exports `<display-google-protobuf-uint32value>` custom-element-definition
 <br>extends */src/typerenderer/display-uint32.js*

--- a/hugo/content/docs/typerenderer/display-google-protobuf-uint64value.md
+++ b/hugo/content/docs/typerenderer/display-google-protobuf-uint64value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-protobuf-uint64value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-protobuf-uint64value.js';`<small>
 <br>exports `<display-google-protobuf-uint64value>` custom-element-definition
 <br>extends */src/typerenderer/display-uint64.js*

--- a/hugo/content/docs/typerenderer/display-google-type-color.md
+++ b/hugo/content/docs/typerenderer/display-google-type-color.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-type-color
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-type-color.js';`<small>
 <br>exports `<display-google-type-color>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-google-type-date.md
+++ b/hugo/content/docs/typerenderer/display-google-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-type-date.js';`<small>
 <br>exports *DisplayGoogleTypeDate* js
 <br>exports `<display-google-type-date>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-google-type-money.md
+++ b/hugo/content/docs/typerenderer/display-google-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-type-money.js';`<small>
 <br>exports *DisplayGoogleTypeMoney* js
 <br>exports `<display-google-type-money>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-google-type-timeofday.md
+++ b/hugo/content/docs/typerenderer/display-google-type-timeofday.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-google-type-timeofday
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-google-type-timeofday.js';`<small>
 <br>exports `<display-google-type-timeofday>` custom-element-definition
 <br>superclass *LitElement*</small>

--- a/hugo/content/docs/typerenderer/display-int32.md
+++ b/hugo/content/docs/typerenderer/display-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-int32.js';`<small>
 <br>exports *DisplayInt32* js
 <br>exports `<display-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-int64.md
+++ b/hugo/content/docs/typerenderer/display-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-int64.js';`<small>
 <br>exports *DisplayInt64* js
 <br>exports `<display-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-string.md
+++ b/hugo/content/docs/typerenderer/display-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-string.js';`<small>
 <br>exports *DisplayString* js
 <br>exports `<display-string>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-uint32.md
+++ b/hugo/content/docs/typerenderer/display-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-uint32.js';`<small>
 <br>exports *DisplayUint32* js
 <br>exports `<display-uint32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/display-uint64.md
+++ b/hugo/content/docs/typerenderer/display-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # display-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/display-uint64.js';`<small>
 <br>exports *DisplayUint64* js
 <br>exports `<display-uint64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-bool.md
+++ b/hugo/content/docs/typerenderer/form-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-bool.js';`<small>
 <br>exports *FormBool* js
 <br>exports `<form-bool>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-double.md
+++ b/hugo/content/docs/typerenderer/form-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-double.js';`<small>
 <br>exports *FormDouble* js
 <br>exports `<form-double>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-float.md
+++ b/hugo/content/docs/typerenderer/form-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-float.js';`<small>
 <br>exports *FormFloat* js
 <br>exports `<form-float>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-furo-bigdecimal.md
+++ b/hugo/content/docs/typerenderer/form-furo-bigdecimal.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-bigdecimal
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-bigdecimal.js';`<small>
 <br>exports *FormFuroBigdecimal* js
 <br>exports `<form-furo-bigdecimal>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-furo-fat-bool.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-bool.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-bool
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-bool.js';`<small>
 <br>exports `<form-furo-fat-bool>` custom-element-definition
 <br>extends */src/typerenderer/form-bool.js*

--- a/hugo/content/docs/typerenderer/form-furo-fat-double.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-double.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-double
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-double.js';`<small>
 <br>exports `<form-furo-fat-double>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-furo-fat-float.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-float.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-float
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-float.js';`<small>
 <br>exports `<form-furo-fat-float>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-furo-fat-int32.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-int32.js';`<small>
 <br>exports *FormFuroFatInt32* js
 <br>exports `<form-furo-fat-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-furo-fat-int64.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-int64.js';`<small>
 <br>exports *FormFuroFatInt64* js
 <br>exports `<form-furo-fat-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-furo-fat-string.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-string.js';`<small>
 <br>exports `<form-furo-fat-string>` custom-element-definition
 <br>extends */src/furo-ui5-text-input-labeled.js*

--- a/hugo/content/docs/typerenderer/form-furo-fat-uint32.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-uint32.js';`<small>
 <br>exports `<form-furo-fat-uint32>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-furo-fat-uint64.md
+++ b/hugo/content/docs/typerenderer/form-furo-fat-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-fat-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-fat-uint64.js';`<small>
 <br>exports `<form-furo-fat-uint64>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-furo-integerproperty.md
+++ b/hugo/content/docs/typerenderer/form-furo-integerproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-integerproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-numberproperty.js';`<small>
 <br>exports `<form-furo-numberproperty>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-furo-reference.md
+++ b/hugo/content/docs/typerenderer/form-furo-reference.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-reference
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-reference.js';`<small>
 <br>exports `<form-furo-reference>` custom-element-definition
 <br>extends */src/furo-ui5-reference-search-labeled.js*

--- a/hugo/content/docs/typerenderer/form-furo-stringoptionproperty.md
+++ b/hugo/content/docs/typerenderer/form-furo-stringoptionproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-stringoptionproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-stringoptionproperty.js';`<small>
 <br>exports `<form-furo-stringoptionproperty>` custom-element-definition
 <br>extends */src/furo-ui5-select-labeled.js*

--- a/hugo/content/docs/typerenderer/form-furo-stringproperty.md
+++ b/hugo/content/docs/typerenderer/form-furo-stringproperty.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-stringproperty
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-stringproperty.js';`<small>
 <br>exports *FormFuroStringproperty* js
 <br>exports `<form-furo-stringproperty>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-furo-type-date.md
+++ b/hugo/content/docs/typerenderer/form-furo-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-type-date.js';`<small>
 <br>exports `<form-furo-type-date>` custom-element-definition
 <br>extends */src/furo-ui5-date-picker-labeled.js*

--- a/hugo/content/docs/typerenderer/form-furo-type-money.md
+++ b/hugo/content/docs/typerenderer/form-furo-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-furo-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-furo-type-money.js';`<small>
 <br>exports `<form-furo-type-money>` custom-element-definition
 <br>extends */src/furo-ui5-money-input-labeled.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-boolvalue.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-boolvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-boolvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-boolvalue.js';`<small>
 <br>exports `<form-google-protobuf-boolvalue>` custom-element-definition
 <br>extends */src/typerenderer/form-bool.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-doublevalue.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-doublevalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-doublevalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-doublevalue.js';`<small>
 <br>exports `<form-google-protobuf-doublevalue>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-floatvalue.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-floatvalue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-floatvalue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-floatvalue.js';`<small>
 <br>exports `<form-google-protobuf-floatvalue>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-int32value.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-int32value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-int32value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-int32value.js';`<small>
 <br>exports `<form-google-protobuf-int32value>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-int64value.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-int64value.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-int64value
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-int64value.js';`<small>
 <br>exports `<form-google-protobuf-int64value>` custom-element-definition
 <br>extends */src/typerenderer/form-int32.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-stringValue.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-stringValue.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-stringValue
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-stringvalue.js';`<small>
 <br>exports `<form-google-protobuf-stringvalue>` custom-element-definition
 <br>extends */src/furo-ui5-text-input-labeled.js*

--- a/hugo/content/docs/typerenderer/form-google-protobuf-timestamp.md
+++ b/hugo/content/docs/typerenderer/form-google-protobuf-timestamp.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-protobuf-timestamp
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-protobuf-timestamp.js';`<small>
 <br>exports `<form-google-protobuf-timestamp>` custom-element-definition
 <br>extends */src/furo-ui5-date-time-picker-labeled.js*

--- a/hugo/content/docs/typerenderer/form-google-type-date.md
+++ b/hugo/content/docs/typerenderer/form-google-type-date.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-type-date
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-type-date.js';`<small>
 <br>exports `<form-google-type-date>` custom-element-definition
 <br>extends */src/furo-ui5-date-picker-labeled.js*

--- a/hugo/content/docs/typerenderer/form-google-type-money.md
+++ b/hugo/content/docs/typerenderer/form-google-type-money.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-type-money
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-type-money.js';`<small>
 <br>exports `<form-google-type-money>` custom-element-definition
 <br>extends */src/furo-ui5-money-input-labeled.js*

--- a/hugo/content/docs/typerenderer/form-google-type-timeofday.md
+++ b/hugo/content/docs/typerenderer/form-google-type-timeofday.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-google-type-timeofday
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-google-type-timeofday.js';`<small>
 <br>exports `<form-google-type-timeofday>` custom-element-definition
 <br>extends */src/furo-ui5-time-picker-labeled.js*

--- a/hugo/content/docs/typerenderer/form-int32.md
+++ b/hugo/content/docs/typerenderer/form-int32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-int32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-int32.js';`<small>
 <br>exports *FormInt32* js
 <br>exports `<form-int32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-int64.md
+++ b/hugo/content/docs/typerenderer/form-int64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-int64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-int64.js';`<small>
 <br>exports *FormInt64* js
 <br>exports `<form-int64>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-string.md
+++ b/hugo/content/docs/typerenderer/form-string.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-string
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-string.js';`<small>
 <br>exports *FormString* js
 <br>exports `<form-string>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-uint32.md
+++ b/hugo/content/docs/typerenderer/form-uint32.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-uint32
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-uint32.js';`<small>
 <br>exports *FormUint32* js
 <br>exports `<form-uint32>` custom-element-definition

--- a/hugo/content/docs/typerenderer/form-uint64.md
+++ b/hugo/content/docs/typerenderer/form-uint64.md
@@ -5,7 +5,7 @@ weight: 50
 ---
 
 # form-uint64
-**@furo/ui5** <small>v1.0.0-rc.24</small>
+**@furo/ui5** <small>v1.0.0-rc.25</small>
 <br>`import '@furo/ui5/src/typerenderer/form-uint64.js';`<small>
 <br>exports *FormUint64* js
 <br>exports `<form-uint64>` custom-element-definition

--- a/src/furo-catalog.js
+++ b/src/furo-catalog.js
@@ -60,3 +60,4 @@ import './furo-ui5-z-grid.js';
 import './ui5-reference-search-item.js';
 import './furo-ui5-combobox.js';
 import './furo-ui5-combobox-labeled.js';
+import './furo-ui5-rating-indicator.js';

--- a/src/furo-ui5-rating-indicator.js
+++ b/src/furo-ui5-rating-indicator.js
@@ -1,0 +1,266 @@
+import * as RatingIndicator from '@ui5/webcomponents/dist/RatingIndicator.js';
+import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
+import { Events } from './lib/Events.js';
+
+/**
+ * The furo-ui5-rating-indicator  is used to display a specific number of icons that are used to rate an item.
+ * Additionally, it is also used to display the average and overall ratings.
+ * https://sap.github.io/ui5-webcomponents/playground/components/RatingIndicator/
+ *
+ * You can bind any `number` type, any `furo.fat.xxx` number type, `furo.BigDecimal` or the `google.wrapper.xxx` number types.
+ *
+ * ```html
+ *  <furo-ui5-rating-indicator
+ *     ƒ-bind-data="--dao(FIELDNODE)"
+ *  ></furo-ui5-rating-indicator>
+ * ```
+ *
+ * ### Specificity
+ * 1. Attributes which are set in the html source will have the highest specificity and will never get overwritten by metas or fat.
+ * 2. Attributes set in meta will have the lowest specificity and will be overwritten by attributes from fat.
+ *
+ * | meta  | fat  | html  |
+ * |------  |-----  |------  |
+ * | 1      | 10    | 100    |
+ *
+ *
+ * ## supported FAT attributes
+ *  - **"readonly":"true"** set the element to readonly
+ *  - **"disabled":"true"** set the element to disabled
+ *
+ * ## supported meta and constraints
+ * - **readonly: true** , set the element to readonly
+ *
+ * ## Methods
+ * **bind-data(fieldNode)**
+ * Bind aa entity field. You can use the entity even when no data was received.
+ *
+ * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
+ *
+ * @fires {`number`} change -  Fired when the values changes.
+ * @fires {`number`} furo-value-changed - Fires the field value when it changes.
+ *
+ * @summary data rating input field
+ * @element furo-ui5-rating-indicator
+ */
+export class FuroUi5RatingIndicator extends FieldNodeAdapter(
+  RatingIndicator.default
+) {
+  constructor() {
+    super();
+
+    /**
+     * @private
+     */
+    this._attributesFromFNA = {
+      readonly: undefined,
+    };
+
+    /**
+     * @private
+     */
+    this._labelsFromFAT = {
+      readonly: undefined,
+      disabled: undefined,
+    };
+
+    /**
+     * a list of privileged attributes. when those attributes are set in number-input components initially.
+     * they can not be modified later via response or spec
+     * null is used because getAttribute returns null or value
+     * @private
+     */
+    this._privilegedAttributes = {
+      readonly: null,
+      disabled: null,
+    };
+
+    this.addEventListener('change', this._updateFNA);
+  }
+
+  /**
+   * connectedCallback() method is called when an element is added to the DOM.
+   * webcomponent lifecycle event
+   * @private
+   */
+  connectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.connectedCallback();
+
+    this.readAttributes();
+  }
+
+  /**
+   * Reads the attributes which are set on the component dom.
+   * those attributes can be set. `readonly`,`disabled`
+   * Use this after manual or scripted update of the attributes.
+   */
+  readAttributes() {
+    // save the original attribute for later usages, we do this, because some components reflect
+    Object.keys(this._privilegedAttributes).forEach(attr => {
+      this._privilegedAttributes[attr] = this.getAttribute(attr);
+    });
+  }
+
+  /**
+   * Handler function for the input value changes.
+   * This is done to be able to remove the event-listeners as a protection for multiple calls
+   * @return {(function(): void)|*}
+   * @private
+   */
+  _updateFNA() {
+    const { value } = this;
+
+    if (this.isFat()) {
+      if (value === '') {
+        this._tmpFAT.value = null;
+        // add empty state
+        if (this._tmpFAT.labels === null) {
+          this._tmpFAT.labels = {};
+        }
+        this._tmpFAT.labels.empty = true;
+      } else {
+        this._tmpFAT.value = parseFloat(value);
+        // remove empty state
+        if (this._tmpFAT.labels && this._tmpFAT.labels.empty) {
+          delete this._tmpFAT.labels.empty;
+        }
+        // init labels in_tmpFAT
+        if (this._tmpFAT.labels === null) {
+          this._tmpFAT.labels = {};
+        }
+        // set modified on changes
+        this._tmpFAT.labels.modified = true;
+      }
+      this.setFnaFieldValue(this._tmpFAT);
+    } else if (this.getDataType() === 'furo.BigDecimal') {
+      const v = { unscaled_value: null, scale: null };
+      if (value !== '') {
+        const matches = value.match(/(\d*)\D(\d*)/);
+        if (matches !== null) {
+          v.scale = matches[2].length;
+          v.unscaled_value = parseInt(matches[1] + matches[2], 10);
+        } else {
+          v.scale = 0;
+          v.unscaled_value = parseInt(value, 10);
+        }
+      }
+
+      this.setFnaFieldValue(v);
+    } else if (this.isWrapper()) {
+      this.setFnaFieldValue(value === '' ? null : parseFloat(value));
+    } else {
+      this.setFnaFieldValue(value === '' ? 0 : parseFloat(value));
+    }
+
+    this.dispatchEvent(Events.buildChangeEvent(this.value));
+  }
+
+  /**
+   * Binds a FieldNode to the component.
+   *
+   * Supported types:
+   * - `double`, `float`, `int32`, `uint32`, `sint32`, `fixed32`, `sfixed32`, `int64`, `uint64`, `sint64`, `fixed64`, `sfixed64`
+   * - `google.protobuf.DoubleValue`, `google.protobuf.FloatValue`, `google.protobuf.Int32Value`, etc.
+   * - `furo.fat.Doube`, `furo.fat.Float`, `furo.fat.Int32`, etc.
+   * - `furo.BigDecimal`
+   * @param fieldNode {FieldNode}
+   */
+  bindData(fieldNode) {
+    return super.bindData(fieldNode);
+  }
+
+  /**
+   * overwrite onFnaFieldValueChanged
+   * @private
+   * @param val
+   */
+  onFnaFieldValueChanged(val) {
+    if (this.isFat()) {
+      this._tmpFAT = val;
+      if (val.value === null || val.value === undefined) {
+        if (val.labels && val.labels.empty) {
+          this.value = 0;
+        } else {
+          this.value = '';
+        }
+      } else {
+        this.value = val.value;
+      }
+
+      // set empty value when label empty was given and the default value is set.
+      if (this._tmpFAT.labels && this._tmpFAT.labels.empty && val.value === 0) {
+        this.value = '';
+      }
+      this._updateLabelsFromFat(this._tmpFAT.labels);
+    } else if (this.getDataType() === 'furo.BigDecimal') {
+      if (val.scale === null && val.unscaled_value === null) {
+        this.value = '';
+      } else {
+        // treat as strings, because
+        // this.value = val.unscaled_value * Math.pow(10, -val.scale)
+        // will not work
+        const vstr = val.unscaled_value.toString(10);
+        if (val.scale < 0) {
+          this.value = parseInt(vstr + ''.padEnd(Math.abs(val.scale), 0), 10);
+        } else {
+          this.value = parseFloat(
+            `${vstr.substr(0, vstr.length - val.scale)}.${vstr.substr(
+              vstr.length - val.scale
+            )}`
+          );
+        }
+      }
+    } else if (val === null || val === undefined) {
+      this.value = '';
+    } else {
+      this.value = val;
+    }
+  }
+
+  /**
+   * labels are map <string,bool>, we handle every boolean attribute with the labels
+   *
+   * @param fatLabels
+   * @private
+   */
+  _updateLabelsFromFat(fatLabels) {
+    if (fatLabels === null || fatLabels === undefined) {
+      return;
+    }
+    // this is needed to check the specificity in the onFnaXXXXChanged callback functions
+    this._labelsFromFAT.readonly = fatLabels.readonly;
+
+    // readonly
+    if (this._privilegedAttributes.readonly === null) {
+      if (fatLabels.readonly !== undefined) {
+        // apply from fat
+        this.readonly = fatLabels.readonly;
+      } else if (this._attributesFromFNA.readonly !== undefined) {
+        // apply from fieldnode (meta)
+        this.readonly = this._attributesFromFNA.readonly;
+      }
+    }
+
+    // disabled
+    if (this._privilegedAttributes.disabled === null) {
+      if (fatLabels.disabled !== undefined) {
+        this.disabled = fatLabels.disabled;
+      }
+    }
+  }
+
+  /**
+   * @private
+   */
+  static get metadata() {
+    const md = super.metadata;
+    md.tag = 'furo-ui5-rating-indicator';
+    return md;
+  }
+
+  static get styles() {
+    return super.styles;
+  }
+}
+FuroUi5RatingIndicator.define();

--- a/src/lib/Events.js
+++ b/src/lib/Events.js
@@ -1,13 +1,11 @@
 /**
  * Event Builder Class
  */
-
-// todo: @maltenorstroem this can cause collisions with ui5 packages, should switch to furo-value-changedd
 const VALUE_CHANGED = 'furo-value-changed';
 
 export class Events {
   /**
-   * Creates an universal `value-changed` event
+   * Creates an universal `furo-value-changed` event
    * All extended ui5 components should use this builder function to create
    * the change event
    * @param detail

--- a/test/furo-ui5-password-input.test.js
+++ b/test/furo-ui5-password-input.test.js
@@ -131,7 +131,7 @@ describe('furo-ui5-password-input', () => {
       assert.equal(input._state.readonly, false, 'check readonly');
       assert.equal(input._state.required, false, 'check required');
       assert.equal(input._state.type, 'Password', 'check type');
-      assert.equal(input._state.value, 'Default Description', 'check value');
+      assert.equal(input._state.value, '', 'check value');
       assert.equal(input._state.valueState, 'None', 'check valueState');
       assert.equal(input._state.name, '', 'check name');
       assert.equal(

--- a/test/furo-ui5-rating-indicator.test.js
+++ b/test/furo-ui5-rating-indicator.test.js
@@ -1,0 +1,109 @@
+import { fixture, html } from '@open-wc/testing';
+
+import { assert } from '@esm-bundle/chai';
+import '../src/furo-catalog.js';
+import '@furo/fbp/src/flow-bind.js'; // for testing with wires and hooks
+// eslint-disable-next-line import/no-extraneous-dependencies
+import './initEnv.js';
+
+describe('furo-ui5-rating-indicator', () => {
+  let riSclar;
+  let riWrapper;
+  let riFat;
+  let input;
+  let host;
+  let dataObject;
+
+  const dataScalar = {"scalar_int32": 4,};
+  const dataWrapper = {"wrapper_int32": 3,};
+  const dataFat = {"fat_int32":{
+    "value": 5,
+    "labels": {
+      "disabled": true
+    },
+    "attributes": {
+      "max": "16",
+    }
+  },};
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <furo-ui5-rating-indicator
+            ƒ-bind-data="--dao(*.scalar_int32)"
+          ></furo-ui5-rating-indicator>
+          <furo-ui5-rating-indicator
+            ƒ-bind-data="--dao(*.wrapper_int32)"
+          ></furo-ui5-rating-indicator>
+          <furo-ui5-rating-indicator
+            ƒ-bind-data="--dao(*.fat_int32)"
+          ></furo-ui5-rating-indicator>
+
+          <furo-ui5-number-input ƒ-bind-data="--dao(*.scalar_int32)"></furo-ui5-number-input>
+
+          <furo-data-object
+            type="universaltest.Universaltest"
+            @-object-ready="--dao"
+          ></furo-data-object>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [
+      ,
+      riSclar, riWrapper, riFat, input, dataObject,
+
+    ] = testbind.parentNode.children;
+    await host.updateComplete;
+    await riSclar.updateComplete;
+    await riWrapper.updateComplete;
+    await riFat.updateComplete;
+    await input.updateComplete;
+    await dataObject.updateComplete;
+
+  });
+
+  it('should be a furo-ui5-rating-indicator', done => {
+    // keep this test on top, so you can recognize a wrong assignment
+    assert.equal(
+      riSclar.nodeName.toLowerCase(),
+      'furo-ui5-rating-indicator'
+    );
+    done();
+  });
+
+  it('should bind a scalar number type', done => {
+    dataObject.addEventListener('data-injected', ()=>{
+      setTimeout(()=>{
+        assert.equal(riSclar.value, 4);
+        done();
+      },10)
+    })
+    dataObject.injectRaw(dataScalar);
+  });
+
+  it('should bind a wrapper number type', done => {
+    dataObject.addEventListener('data-injected', ()=>{
+      setTimeout(()=>{
+        assert.equal(riWrapper.value, 3);
+        done();
+      },10)
+    })
+    dataObject.injectRaw(dataWrapper);
+  });
+
+  it('should bind a fat number type', done => {
+    dataObject.addEventListener('data-injected', ()=>{
+      setTimeout(()=>{
+        assert.equal(riFat.value, 5);
+        assert.equal(riFat.disabled, true);
+        done();
+      },10)
+    })
+    dataObject.injectRaw(dataFat);
+  });
+
+
+});

--- a/test/furo-ui5-text-input-scalar.test.js
+++ b/test/furo-ui5-text-input-scalar.test.js
@@ -85,7 +85,7 @@ describe('furo-ui5-text-input-scalar', () => {
       assert.equal(input._state.readonly, false, 'check readonly');
       assert.equal(input._state.required, false, 'check required');
       assert.equal(input._state.type, 'Text', 'check type');
-      assert.equal(input._state.value, 'Default Description', 'check value');
+      assert.equal(input._state.value, '', 'check value');
       assert.equal(input._state.valueState, 'None', 'check valueState');
       assert.equal(input._state.name, '', 'check name');
       assert.equal(

--- a/test/furo-ui5-textarea-input.test.js
+++ b/test/furo-ui5-textarea-input.test.js
@@ -214,7 +214,7 @@ describe('furo-ui5-textarea-input', () => {
         );
         assert.equal(inputFat._state.valueState, 'Error', 'check valueState');
         assert.equal(
-          inputFat._valueStateElement.innerText,
+          inputFat.querySelector('div[slot="valueStateMessage"]').innerText,
           'Your fat string is valid',
           'check valueStateMessage content'
         );


### PR DESCRIPTION
Binds a FieldNode to the component.

## Supported types:
- `double`, `float`, `int32`, `uint32`, `sint32`, `fixed32`, `sfixed32`, `int64`, `uint64`, `sint64`, `fixed64`, `sfixed64`
- `google.protobuf.DoubleValue`, `google.protobuf.FloatValue`, `google.protobuf.Int32Value`, etc.
- `furo.fat.Doube`, `furo.fat.Float`, `furo.fat.Int32`, etc.
- `furo.BigDecimal`

## Supported FAT attributes
 - **"readonly":"true"** set the element to readonly
 - **"disabled":"true"** set the element to disabled

**max** (The number of displayed rating symbols.) can be set as an attribute.
`<furo-ui5-rating-indicator max="33" ƒ-bind-data="--daoPerson(*.bmi)"></furo-ui5-rating-indicator>`