### PR TITLE
fix: issue-32, leaving searcher behaviours

### DIFF
--- a/demos/reference-search.html
+++ b/demos/reference-search.html
@@ -22,7 +22,7 @@
     import '../src/furo-ui5-reference-search.js';
     import '../src/furo-ui5-reference-search-labeled.js';
 
-    import '@furo/data/src/furo-catalog.js';
+    import '@furo/data/src/furo-data-object.js';
     import '@furo/util/src/furo-fetch-json.js';
     import '@furo/util/src/doc/furo-demo-snippet.js';
     import '@furo/layout/src/furo-form-layouter.js';
@@ -42,12 +42,14 @@
             <furo-form-layouter four="">
               <furo-ui5-reference-search ƒ-bind-data="--entityReady(*.owner)" extended-searcher="demo-extended-searcher" min-term-length="1">
               </furo-ui5-reference-search>
+
               <furo-ui5-reference-search ƒ-bind-data="--entityReady(*.owner)" extended-searcher="demo-extended-searcher" min-term-length="1">
               </furo-ui5-reference-search>
 
-              <furo-ui5-reference-search-labeled no-data-text="some" ƒ-bind-data="--entityReady(*.owner)" extended-searcher="demo-extended-searcher" min-term-length="1">
+              <furo-ui5-reference-search-labeled  newline no-data-text="some" ƒ-bind-data="--entityReady(*.owner)" extended-searcher="demo-extended-searcher" min-term-length="1">
               </furo-ui5-reference-search-labeled>
             </furo-form-layouter>
+
             <furo-data-object type="task.Task" @-object-ready="--entityReady">
             </furo-data-object>
           </template>

--- a/hugo/content/docs/components/furo-ui5-reference-search.md
+++ b/hugo/content/docs/components/furo-ui5-reference-search.md
@@ -29,7 +29,7 @@ Do not forget to specify.
   ></furo-ui5-reference-search>
 ```
 
- *usage with a extended searcher*
+ *usage with an extended searcher*
 ```html
   <furo-ui5-reference-search
   extended-searcher="country-filter"
@@ -58,12 +58,12 @@ The constraint **required** will mark the element as required
 If your type has a *reference* type signature ('id','display_name', 'link'), the service, and initial deep link is extracted from
 the link part of your type.
 
-If you bind a skalar field, the value which is set in 'valueFieldPath' will be set.
+If you bind a scalar field, the value which is set in 'valueFieldPath' will be set.
 
 When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
 
 ## Specs
-Define a propper default value on the reference type.
+Define a proper default value on the reference type.
 
 ```yaml
 link:
@@ -79,7 +79,7 @@ meta:
          "href": "/contacts",
          "method": "GET",
          "type": "contact.Contact",
-         "service": "Contacts"
+         "service": "contact.Contacts"
      }
   placeholder: ""
   hint: ""
@@ -92,8 +92,8 @@ meta:
   typespecific: null
 
 ```
-### API of a extended searcher
-### Searcher Mehtods
+### API of an extended searcher
+### Searcher Methods
 The only method you have to implement is **htsIn**. The reference-search will pass its own hts to the extended
 searcher. A call on qpIn on the searcher will also pass the resulting hts to the extended searcher.
 
@@ -171,7 +171,7 @@ By default this goes to *data.display_name*
 <span  style="border-width:2px; border-style: solid;border-color:  rgb(255, 182, 91);font-family:monospace; padding:2px 4px;">extended-value-field-path</span>
 <small>`string` default: **&#39;data.id&#39;**</small>
 
-Path to response value item of the exteded search which is used for the id.
+Path to response value item of the extended search which is used for the id.
 By default this goes to *data.id*.
 Only needed when your extended searcher does not have the id, display_name signature in the response.
 <br><br>
@@ -371,7 +371,8 @@ Define the extended searcher. Do not forget to import the searcher you want to u
 
 Binds a FieldNode to the component.
 
-Supported types: can be a scalar type or any complex type with 'id','display_name' signature.
+Supported types: can be a scalar type or any complex type with 'id','display_name' signature or use
+the furo.Reference type.
 
 - <small>fieldNode </small>
 <br><br>

--- a/src/furo-ui5-reference-search.js
+++ b/src/furo-ui5-reference-search.js
@@ -1,17 +1,18 @@
 import { LitElement, html, css } from 'lit';
-
 import { FBP } from '@furo/fbp';
 import { FieldNodeAdapter } from '@furo/data/src/lib/FieldNodeAdapter.js';
 import { Env } from '@furo/framework';
+
 import '@furo/data/src/furo-collection-agent.js';
 import '@furo/fbp/src/flow-repeat.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@furo/util/src/furo-de-bounce.js';
 import '@ui5/webcomponents/dist/Input.js';
 import '@ui5/webcomponents/dist/List.js';
-import './ui5-reference-search-item.js';
 import '@ui5/webcomponents-icons/dist/value-help.js';
 import '@ui5/webcomponents-icons/dist/search.js';
+
+import './ui5-reference-search-item.js';
 import './furo-ui5-dialog.js';
 
 /**
@@ -27,7 +28,7 @@ import './furo-ui5-dialog.js';
  *   ></furo-ui5-reference-search>
  * ```
  *
- *  *usage with a extended searcher*
+ *  *usage with an extended searcher*
  * ```html
  *   <furo-ui5-reference-search
  *   extended-searcher="country-filter"
@@ -56,12 +57,12 @@ import './furo-ui5-dialog.js';
  * If your type has a *reference* type signature ('id','display_name', 'link'), the service, and initial deep link is extracted from
  * the link part of your type.
  *
- * If you bind a skalar field, the value which is set in 'valueFieldPath' will be set.
+ * If you bind a scalar field, the value which is set in 'valueFieldPath' will be set.
  *
  * When you use @-object-ready from a furo-data-object which emits a EntityNode, just bind the field with --entity(*.fields.fieldname)
  *
  * ## Specs
- * Define a propper default value on the reference type.
+ * Define a proper default value on the reference type.
  *
  * ```yaml
  * link:
@@ -77,7 +78,7 @@ import './furo-ui5-dialog.js';
  *          "href": "/contacts",
  *          "method": "GET",
  *          "type": "contact.Contact",
- *          "service": "Contacts"
+ *          "service": "contact.Contacts"
  *      }
  *   placeholder: ""
  *   hint: ""
@@ -90,8 +91,8 @@ import './furo-ui5-dialog.js';
  *   typespecific: null
  *
  * ```
- * ### API of a extended searcher
- * ### Searcher Mehtods
+ * ### API of an extended searcher
+ * ### Searcher Methods
  * The only method you have to implement is **htsIn**. The reference-search will pass its own hts to the extended
  * searcher. A call on qpIn on the searcher will also pass the resulting hts to the extended searcher.
  *
@@ -272,7 +273,8 @@ export class FuroUi5ReferenceSearch extends FBP(FieldNodeAdapter(LitElement)) {
   /**
    * Binds a FieldNode to the component.
    *
-   * Supported types: can be a scalar type or any complex type with 'id','display_name' signature.
+   * Supported types: can be a scalar type or any complex type with 'id','display_name' signature or use
+   * the furo.Reference type.
    * @param fieldNode {FieldNode}
    */
   bindData(fieldNode) {
@@ -316,7 +318,7 @@ export class FuroUi5ReferenceSearch extends FBP(FieldNodeAdapter(LitElement)) {
        */
       displayFieldPath: { type: String, attribute: 'display-field-path' },
       /**
-       * Path to response value item of the exteded search which is used for the id.
+       * Path to response value item of the extended search which is used for the id.
        * By default this goes to *data.id*.
        * Only needed when your extended searcher does not have the id, display_name signature in the response.
        */
@@ -653,6 +655,9 @@ export class FuroUi5ReferenceSearch extends FBP(FieldNodeAdapter(LitElement)) {
 
       if (!this._lockBlur) {
         this._closeList();
+        // When the field is left, the value from the model should be displayed. The entered search term is removed.
+        const INPUT_FIELD = this.shadowRoot.querySelector('#input');
+        INPUT_FIELD.value = this.value.display_name;
       }
     });
 
@@ -681,7 +686,7 @@ export class FuroUi5ReferenceSearch extends FBP(FieldNodeAdapter(LitElement)) {
     });
 
     /**
-     * Update the fieldnode when an item from the list was selected
+     * Update the field node when an item from the list was selected
      */
     this._FBPAddWireHook('--itemSelected', item => {
       this.value.id = this.valueFieldPath


### PR DESCRIPTION
**This pull request changes the following behaviour of the reference search component:**
When the field is left, the value from the model should be displayed. The entered search term is removed.