### PR TITLE
fix: text alignement in cell renderers

### DIFF
--- a/src/typerenderer/cell-google-protobuf-timestamp.js
+++ b/src/typerenderer/cell-google-protobuf-timestamp.js
@@ -31,7 +31,6 @@ class CellGoogleProtobufTimestamp extends LitElement {
     return css`
       :host {
         display: block;
-        text-align: right;
         white-space: nowrap;
       }
 

--- a/src/typerenderer/cell-google-type-color.js
+++ b/src/typerenderer/cell-google-type-color.js
@@ -26,7 +26,6 @@ class CellGoolgeTypeColor extends LitElement {
     return css`
       :host {
         display: block;
-        text-align: right;
       }
 
       :host([hidden]) {

--- a/src/typerenderer/cell-google-type-date.js
+++ b/src/typerenderer/cell-google-type-date.js
@@ -31,7 +31,6 @@ export class CellGoogleTypeDate extends LitElement {
     return css`
       :host {
         display: block;
-        text-align: right;
         white-space: nowrap;
       }
 

--- a/src/typerenderer/cell-google-type-timeofday.js
+++ b/src/typerenderer/cell-google-type-timeofday.js
@@ -31,7 +31,6 @@ class CellGoogleTypeTimeofday extends LitElement {
     return css`
       :host {
         display: block;
-        text-align: right;
         white-space: nowrap;
       }
 


### PR DESCRIPTION
Dates (in any format) should ideally be left-aligned inside a data table column.

A rule of thumb is: integers should be right aligned, while other types of data should be left aligned.

The default alignment for most types of data is left alignment -- this helps make the data easily scannable, readable and comparable.

https://ux.stackexchange.com/questions/117685/in-tables-should-date-time-year-in-table-be-left-or-right-aligned#:~:text=Dates%20(in%20any%20format)%20should,data%20should%20be%20left%20aligned.